### PR TITLE
Initialize multi-module Kotlin bot monorepo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,9 @@
-.gradle
+.gradle/
 build/
-!gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**/build/
-!**/src/test/**/build/
-
-### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
-*.iws
+*/build/
+!.gradle/wrapper/gradle-wrapper.jar
+!.gradle/wrapper/gradle-wrapper.properties
+.idea/
 *.iml
-*.ipr
 out/
-!**/src/main/**/out/
-!**/src/test/**/out/
-
-### Eclipse ###
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
-.sts4-cache
-bin/
-!**/src/main/**/bin/
-!**/src/test/**/bin/
-
-### NetBeans ###
-/nbproject/private/
-/nbbuild/
-/dist/
-/nbdist/
-/.nb-gradle/
-
-### VS Code ###
-.vscode/
-
-### Mac OS ###
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Bot Monorepo
+
+This repository contains a Kotlin multi-module project built with Gradle Kotlin DSL.
+
+## Modules
+
+- `app-bot` – Ktor HTTP service handling Telegram webhook.
+- `core-domain` – Domain models and result types.
+- `core-data` – Database access using Exposed, HikariCP and Flyway.
+- `core-telemetry` – Micrometer metrics and health endpoints.
+- `core-security` – RBAC and request signature utilities.
+- `core-testing` – Shared test fixtures.
+
+## Building
+
+```bash
+./gradlew build
+./gradlew detekt ktlintCheck
+```
+
+## Running the bot
+
+```bash
+./gradlew :app-bot:run
+```

--- a/app-bot/build.gradle.kts
+++ b/app-bot/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    application
+}
+
+dependencies {
+    implementation(projects.coreDomain)
+    implementation(projects.coreData)
+    implementation(projects.coreTelemetry)
+    implementation(projects.coreSecurity)
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.logback)
+    testImplementation(projects.coreTesting)
+    testImplementation(libs.ktor.server.tests)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
+    testImplementation(libs.mockk)
+}
+
+application {
+    mainClass.set("com.example.bot.app.BotApplicationKt")
+}

--- a/app-bot/src/main/kotlin/com/example/bot/app/BotApplication.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/app/BotApplication.kt
@@ -1,0 +1,41 @@
+package com.example.bot.app
+
+import com.example.bot.telemetry.Telemetry.configureMonitoring
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receive
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TelegramMessage(val text: String? = null)
+
+@Serializable
+data class TelegramUpdate(val updateId: Long, val message: TelegramMessage?)
+
+fun Application.module() {
+    install(ContentNegotiation) {
+        json()
+    }
+    configureMonitoring()
+    routing {
+        post("/webhook") {
+            val update = call.receive<TelegramUpdate>()
+            val reply = update.message?.text ?: ""
+            call.respondText(reply)
+        }
+    }
+}
+
+fun main() {
+    embeddedServer(Netty, port = 8080, host = "0.0.0.0") {
+        module()
+    }.start(wait = true)
+}

--- a/app-bot/src/test/kotlin/com/example/bot/app/BotApplicationTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/app/BotApplicationTest.kt
@@ -1,0 +1,27 @@
+package com.example.bot.app
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+
+class BotApplicationTest : StringSpec({
+    "echoes message" {
+        testApplication {
+            application { module() }
+            val response =
+                client.post("/webhook") {
+                    headers { append(HttpHeaders.ContentType, ContentType.Application.Json.toString()) }
+                    setBody("{\"updateId\":1,\"message\":{\"text\":\"hi\"}}")
+                }
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldBe "hi"
+        }
+    }
+})

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,31 @@
+import org.gradle.api.tasks.testing.Test
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+
 plugins {
-    id("java")
+    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.ksp) apply false
 }
 
-group = "org.example"
-version = "1.0-SNAPSHOT"
-
-repositories {
-    mavenCentral()
+allprojects {
+    repositories {
+        mavenCentral()
+    }
 }
 
-dependencies {
-    testImplementation(platform("org.junit:junit-bom:5.10.0"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-}
+subprojects {
+    apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+    apply(plugin = "io.gitlab.arturbosch.detekt")
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
-tasks.test {
-    useJUnitPlatform()
+    extensions.configure<KotlinJvmProjectExtension> {
+        jvmToolchain(21)
+    }
+
+    tasks.withType<Test>().configureEach {
+        useJUnitPlatform()
+    }
 }

--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    implementation(projects.coreDomain)
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.dao)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.hikari)
+    implementation(libs.flyway)
+    implementation(libs.postgres)
+    implementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
+    testImplementation(libs.mockk)
+    testImplementation(libs.h2)
+    testImplementation(projects.coreTesting)
+}

--- a/core-data/src/main/kotlin/com/example/bot/data/DatabaseFactory.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/DatabaseFactory.kt
@@ -1,0 +1,29 @@
+package com.example.bot.data
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.flywaydb.core.Flyway
+import org.jetbrains.exposed.sql.Database
+
+private const val MAX_POOL_SIZE = 3
+
+object DatabaseFactory {
+    fun connect(
+        url: String,
+        driver: String,
+        user: String? = null,
+        password: String? = null,
+    ): Database {
+        val config =
+            HikariConfig().apply {
+                jdbcUrl = url
+                username = user
+                this.password = password
+                driverClassName = driver
+                maximumPoolSize = MAX_POOL_SIZE
+            }
+        val dataSource = HikariDataSource(config)
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        return Database.connect(dataSource)
+    }
+}

--- a/core-data/src/test/kotlin/com/example/bot/data/DatabaseFactoryTest.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/DatabaseFactoryTest.kt
@@ -1,0 +1,11 @@
+package com.example.bot.data
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+class DatabaseFactoryTest : StringSpec({
+    "connects to H2" {
+        val db = DatabaseFactory.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "org.h2.Driver")
+        db.shouldNotBeNull()
+    }
+})

--- a/core-domain/build.gradle.kts
+++ b/core-domain/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
+}
+
+dependencies {
+    implementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
+    testImplementation(libs.mockk)
+}

--- a/core-domain/src/main/kotlin/com/example/bot/domain/AppResult.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/domain/AppResult.kt
@@ -1,0 +1,7 @@
+package com.example.bot.domain
+
+sealed class AppResult<out T> {
+    data class Ok<T>(val value: T) : AppResult<T>()
+
+    data class Err(val reason: String) : AppResult<Nothing>()
+}

--- a/core-domain/src/main/kotlin/com/example/bot/domain/User.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/domain/User.kt
@@ -1,0 +1,10 @@
+package com.example.bot.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class User(val id: Long, val name: String, val role: String) {
+    init {
+        require(name.isNotBlank()) { "name must not be blank" }
+    }
+}

--- a/core-domain/src/test/kotlin/com/example/bot/domain/UserTest.kt
+++ b/core-domain/src/test/kotlin/com/example/bot/domain/UserTest.kt
@@ -1,0 +1,10 @@
+package com.example.bot.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+
+class UserTest : StringSpec({
+    "blank name fails" {
+        shouldThrow<IllegalArgumentException> { User(1, "", "ADMIN") }
+    }
+})

--- a/core-security/build.gradle.kts
+++ b/core-security/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
+    testImplementation(libs.mockk)
+}

--- a/core-security/src/main/kotlin/com/example/bot/security/Security.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/Security.kt
@@ -1,0 +1,47 @@
+package com.example.bot.security
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+private const val HEX_MASK = 0xff
+private const val HEX_BASE = 0x100
+private const val HEX_TRIM = 1
+private const val HEX_RADIX = 16
+
+enum class Role {
+    USER,
+    ADMIN,
+}
+
+class AccessController(
+    private val permissions: Map<Role, Set<String>>,
+) {
+    fun isAllowed(
+        role: Role,
+        action: String,
+    ): Boolean {
+        return permissions[role]?.contains(action) ?: false
+    }
+}
+
+object SignatureValidator {
+    fun sign(
+        secret: String,
+        data: String,
+    ): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA256"))
+        return mac.doFinal(data.toByteArray()).joinToString("") { byte ->
+            val hex = (byte.toInt() and HEX_MASK) + HEX_BASE
+            hex.toString(HEX_RADIX).substring(HEX_TRIM)
+        }
+    }
+
+    fun verify(
+        secret: String,
+        data: String,
+        signature: String,
+    ): Boolean {
+        return sign(secret, data) == signature
+    }
+}

--- a/core-security/src/test/kotlin/com/example/bot/security/SecurityTest.kt
+++ b/core-security/src/test/kotlin/com/example/bot/security/SecurityTest.kt
@@ -1,0 +1,23 @@
+package com.example.bot.security
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SecurityTest : StringSpec({
+    "rbac check" {
+        val controller =
+            AccessController(
+                mapOf(
+                    Role.ADMIN to setOf("write"),
+                    Role.USER to setOf("read"),
+                ),
+            )
+        controller.isAllowed(Role.USER, "read") shouldBe true
+        controller.isAllowed(Role.USER, "write") shouldBe false
+    }
+
+    "signature" {
+        val sig = SignatureValidator.sign("k", "data")
+        SignatureValidator.verify("k", "data", sig) shouldBe true
+    }
+})

--- a/core-telemetry/build.gradle.kts
+++ b/core-telemetry/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    implementation(libs.micrometer.core)
+    implementation(libs.micrometer.prometheus)
+    implementation(libs.ktor.server.core)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
+    testImplementation(libs.mockk)
+}

--- a/core-telemetry/src/main/kotlin/com/example/bot/telemetry/Telemetry.kt
+++ b/core-telemetry/src/main/kotlin/com/example/bot/telemetry/Telemetry.kt
@@ -1,0 +1,27 @@
+package com.example.bot.telemetry
+
+import io.ktor.http.ContentType
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
+
+object Telemetry {
+    val registry: MeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+    fun Application.configureMonitoring() {
+        routing {
+            get("/metrics") {
+                val metrics = (registry as PrometheusMeterRegistry).scrape()
+                call.respondText(metrics, ContentType.parse("text/plain"))
+            }
+            get("/health") {
+                call.respondText("OK")
+            }
+        }
+    }
+}

--- a/core-telemetry/src/test/kotlin/com/example/bot/telemetry/TelemetryTest.kt
+++ b/core-telemetry/src/test/kotlin/com/example/bot/telemetry/TelemetryTest.kt
@@ -1,0 +1,11 @@
+package com.example.bot.telemetry
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.micrometer.prometheus.PrometheusMeterRegistry
+
+class TelemetryTest : StringSpec({
+    "registry is prometheus" {
+        Telemetry.registry.shouldBeInstanceOf<PrometheusMeterRegistry>()
+    }
+})

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    implementation(projects.coreDomain)
+    implementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
+    testImplementation(libs.mockk)
+}

--- a/core-testing/src/main/kotlin/com/example/bot/testing/UserFactory.kt
+++ b/core-testing/src/main/kotlin/com/example/bot/testing/UserFactory.kt
@@ -1,0 +1,13 @@
+package com.example.bot.testing
+
+import com.example.bot.domain.User
+
+object UserFactory {
+    fun create(
+        id: Long = 1,
+        name: String = "test",
+        role: String = "USER",
+    ): User {
+        return User(id = id, name = name, role = role)
+    }
+}

--- a/core-testing/src/test/kotlin/com/example/bot/testing/UserFactoryTest.kt
+++ b/core-testing/src/test/kotlin/com/example/bot/testing/UserFactoryTest.kt
@@ -1,0 +1,12 @@
+package com.example.bot.testing
+
+import com.example.bot.domain.User
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class UserFactoryTest : StringSpec({
+    "creates user" {
+        val user = UserFactory.create()
+        user shouldBe User(1, "test", "USER")
+    }
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,48 @@
+[versions]
+kotlin = "1.9.23"
+ksp = "1.9.23-1.0.19"
+ktor = "2.3.7"
+serialization = "1.6.3"
+exposed = "0.49.0"
+hikari = "5.1.0"
+flyway = "10.16.0"
+postgres = "42.7.2"
+h2 = "2.2.224"
+micrometer = "1.12.3"
+logback = "1.4.14"
+junit = "5.10.2"
+kotest = "5.8.0"
+mockk = "1.13.10"
+detekt = "1.23.6"
+ktlint = "12.1.1"
+coroutines = "1.8.1"
+
+[libraries]
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-tests = { module = "io.ktor:ktor-server-tests-jvm", version.ref = "ktor" }
+exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
+flyway = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
+micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
+micrometer-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Sep 04 18:43:04 MSK 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,19 @@
 rootProject.name = "bot_for_add_prod"
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+include(
+    "app-bot",
+    "core-domain",
+    "core-data",
+    "core-telemetry",
+    "core-security",
+    "core-testing"
+)


### PR DESCRIPTION
## Summary
- Set up Gradle 9 Kotlin multi-module project with version catalog and code style tools
- Implement core modules for domain, data, telemetry, security, testing, and a Ktor-based bot app
- Add tests, README, editorconfig and Gradle wrapper 9.0.0

## Testing
- `./gradlew build --console=plain`
- `./gradlew detekt ktlintCheck --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68bb99ea2c5483219742afbad2e13208