### PR TITLE
feat: add basic security scaffolding

### DIFF
--- a/app-bot/build.gradle.kts
+++ b/app-bot/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.server.cors)
+    implementation(libs.ktor.server.auth)
+    implementation(libs.ktor.server.status.pages)
     implementation(libs.logback)
     testImplementation(projects.coreTesting)
     testImplementation(libs.ktor.server.tests)

--- a/app-bot/src/main/kotlin/com/example/bot/app/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/app/Application.kt
@@ -5,6 +5,7 @@ import com.example.bot.availability.AvailabilityService
 import com.example.bot.policy.CutoffPolicy
 import com.example.bot.routes.availabilityRoutes
 import com.example.bot.routes.bookingRoutes
+import com.example.bot.plugins.configureSecurity
 import com.example.bot.booking.BookingService
 import com.example.bot.data.booking.InMemoryBookingRepository
 import com.example.bot.data.outbox.InMemoryOutboxService
@@ -27,7 +28,6 @@ import io.ktor.server.routing.routing
 import kotlinx.serialization.Serializable
 import java.time.Instant
 import java.time.LocalDate
-
 
 @Serializable
 data class TelegramMessage(val text: String? = null)
@@ -61,7 +61,7 @@ fun Application.module() {
     val apiBase = routes.property("api").getString()
 
     configureMonitoring(metricsPath, healthPath)
-
+    configureSecurity()
     val repository = DummyAvailabilityRepository
     val resolver = OperatingRulesResolver(repository)
     val cutoffPolicy = CutoffPolicy()
@@ -118,4 +118,3 @@ private object DummyAvailabilityRepository : AvailabilityRepository {
 
     override suspend fun listActiveBookingTableIds(eventId: Long) = emptySet<Long>()
 }
-

--- a/app-bot/src/main/kotlin/com/example/bot/plugins/SecurityPlugins.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/plugins/SecurityPlugins.kt
@@ -1,0 +1,35 @@
+package com.example.bot.plugins
+
+import com.example.bot.security.auth.AuthProviders.telegramWebAppAuth
+import com.example.bot.security.auth.AuthProviders.telegramWebhookAuth
+import com.example.bot.security.rbac.AuthorizationException
+import com.example.bot.security.rbac.RoleCache
+import com.example.bot.security.rbac.RoleRepository
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respond
+
+/**
+ * Installs authentication and basic error handling.
+ */
+fun Application.configureSecurity() {
+    val repository = object : RoleRepository {
+        override suspend fun findRoles(userId: Long) = emptySet<com.example.bot.security.rbac.RoleAssignment>()
+    }
+    val cache = RoleCache(repository)
+    install(Authentication) {
+        telegramWebhookAuth("secret") { cache.rolesFor(it) }
+        telegramWebAppAuth("token") { cache.rolesFor(it) }
+    }
+    install(StatusPages) {
+        exception<AuthorizationException> { call, cause ->
+            call.respond(HttpStatusCode.Forbidden, mapOf("error" to cause.message))
+        }
+        exception<Throwable> { call, cause ->
+            call.respond(HttpStatusCode.InternalServerError, mapOf("error" to (cause.message ?: "error")))
+        }
+    }
+}

--- a/app-bot/src/main/kotlin/com/example/bot/routes/SecuredRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/SecuredRoutes.kt
@@ -1,0 +1,35 @@
+package com.example.bot.routes
+
+import com.example.bot.security.rbac.anyOf
+import com.example.bot.security.rbac.globalAuthorize
+import com.example.bot.security.rbac.clubScopedAuthorize
+import com.example.bot.security.rbac.RoleCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+
+/**
+ * Example secured HTTP routes using RBAC DSL.
+ */
+fun Application.securedRoutes() {
+    routing {
+        globalAuthorize(anyOf(RoleCode.OWNER, RoleCode.GLOBAL_ADMIN, RoleCode.HEAD_MANAGER)) {
+            get("/api/admin/overview") {
+                call.respondText("overview")
+            }
+        }
+        route("/api/clubs/{clubId}") {
+            clubScopedAuthorize(anyOf(RoleCode.CLUB_ADMIN, RoleCode.MANAGER, RoleCode.ENTRY_MANAGER)) {
+                get("/bookings") { call.respondText("bookings") }
+                post("/checkin/scan") { call.respondText("scan") }
+            }
+            clubScopedAuthorize(anyOf(RoleCode.PROMOTER, RoleCode.CLUB_ADMIN, RoleCode.MANAGER, RoleCode.GUEST)) {
+                post("/tables/{tableId}/booking") { call.respondText("booked") }
+            }
+        }
+    }
+}

--- a/core-security/build.gradle.kts
+++ b/core-security/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.auth)
+    implementation(libs.kotlinx.serialization.json)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotest.runner)
     testImplementation(libs.kotest.assertions)

--- a/core-security/src/main/kotlin/com/example/bot/security/auth/AuthProviders.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/auth/AuthProviders.kt
@@ -1,0 +1,23 @@
+package com.example.bot.security.auth
+
+import com.example.bot.security.rbac.RoleAssignment
+import io.ktor.server.auth.AuthenticationConfig
+
+/**
+ * Stub authentication providers. Real implementation should integrate with Telegram.
+ */
+object AuthProviders {
+    fun AuthenticationConfig.telegramWebhookAuth(
+        secretToken: String,
+        rolesProvider: suspend (Long) -> Set<RoleAssignment>,
+    ) {
+        // no-op stub
+    }
+
+    fun AuthenticationConfig.telegramWebAppAuth(
+        botToken: String,
+        rolesProvider: suspend (Long) -> Set<RoleAssignment>,
+    ) {
+        // no-op stub
+    }
+}

--- a/core-security/src/main/kotlin/com/example/bot/security/auth/InitDataValidator.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/auth/InitDataValidator.kt
@@ -1,0 +1,52 @@
+package com.example.bot.security.auth
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Validates Telegram Mini App init data according to official algorithm.
+ */
+object InitDataValidator {
+    private val json = Json
+
+    /**
+     * Parses and validates raw init data. Returns user information if valid, or null otherwise.
+     */
+    fun validate(initData: String, botToken: String): TelegramUser? {
+        val params = initData.split('&').map { part ->
+            val idx = part.indexOf('=')
+            if (idx == -1) part to "" else {
+                val key = part.substring(0, idx)
+                val value = part.substring(idx + 1)
+                key to URLDecoder.decode(value, StandardCharsets.UTF_8)
+            }
+        }.toMap()
+        val hash = params["hash"] ?: return null
+        val dataCheckString = params.filterKeys { it != "hash" }
+            .toList()
+            .sortedBy { it.first }
+            .joinToString("\n") { "${it.first}=${it.second}" }
+        val secretKey = MessageDigest.getInstance("SHA-256").digest(botToken.toByteArray())
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secretKey, "HmacSHA256"))
+        val check = mac.doFinal(dataCheckString.toByteArray())
+        val hex = check.joinToString("") { "%02x".format(it) }
+        if (hex != hash) return null
+        val userJson = params["user"] ?: return null
+        return json.decodeFromString(TelegramUser.serializer(), userJson)
+    }
+}
+
+/**
+ * Minimal representation of Telegram user contained in init data.
+ */
+@Serializable
+data class TelegramUser(
+    val id: Long,
+    val username: String? = null,
+)

--- a/core-security/src/main/kotlin/com/example/bot/security/auth/TelegramPrincipal.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/auth/TelegramPrincipal.kt
@@ -1,0 +1,17 @@
+package com.example.bot.security.auth
+
+import com.example.bot.security.rbac.RoleAssignment
+import io.ktor.server.auth.Principal
+
+/**
+ * Principal representing an authenticated Telegram user.
+ *
+ * @property telegramUserId Telegram numeric identifier
+ * @property username Optional Telegram username
+ * @property roles Assigned roles for this user
+ */
+data class TelegramPrincipal(
+    val telegramUserId: Long,
+    val username: String?,
+    val roles: Set<RoleAssignment>,
+) : Principal

--- a/core-security/src/main/kotlin/com/example/bot/security/rbac/Policy.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/rbac/Policy.kt
@@ -1,0 +1,66 @@
+package com.example.bot.security.rbac
+
+import com.example.bot.security.auth.TelegramPrincipal
+import io.ktor.http.HttpMethod
+import io.ktor.server.application.call
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.principal
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.httpMethod
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.Routing
+import io.ktor.server.application.ApplicationCallPipeline
+
+/**
+ * Exception thrown when authorization fails.
+ */
+class AuthorizationException(message: String = "Forbidden") : RuntimeException(message)
+
+/**
+ * Utility function that returns a set of roles that satisfy any-of requirement.
+ */
+fun anyOf(vararg codes: RoleCode): Set<RoleCode> = codes.toSet()
+
+private fun TelegramPrincipal.hasRole(required: Set<RoleCode>, clubId: Long?): Boolean =
+    roles.any { assignment ->
+        assignment.code in required && when (val scope = assignment.scope) {
+            is Scope.Global -> true
+            is Scope.Club -> clubId != null && scope.clubId == clubId
+        }
+    }
+
+private fun HttpMethod.isWrite(): Boolean = this != HttpMethod.Get && this != HttpMethod.Head
+
+/**
+ * Authorizes global routes.
+ */
+fun Routing.globalAuthorize(required: Set<RoleCode>, build: Route.() -> Unit) {
+    authenticate("telegram-webhook", "telegram-webapp") {
+        intercept(ApplicationCallPipeline.Plugins) {
+            val principal = call.principal<TelegramPrincipal>() ?: throw AuthorizationException("unauthenticated")
+            if (!principal.hasRole(required, null)) throw AuthorizationException("forbidden")
+            if (principal.roles.any { it.code == RoleCode.HEAD_MANAGER } && call.request.httpMethod.isWrite()) {
+                throw AuthorizationException("read_only")
+            }
+        }
+        build()
+    }
+}
+
+/**
+ * Authorizes club scoped routes.
+ */
+fun Route.clubScopedAuthorize(required: Set<RoleCode>, build: Route.() -> Unit) {
+    authenticate("telegram-webhook", "telegram-webapp") {
+        intercept(ApplicationCallPipeline.Plugins) {
+            val principal = call.principal<TelegramPrincipal>() ?: throw AuthorizationException("unauthenticated")
+            val clubParam = call.parameters["clubId"] ?: throw BadRequestException("clubId")
+            val clubId = clubParam.toLongOrNull() ?: throw BadRequestException("clubId")
+            if (!principal.hasRole(required, clubId)) throw AuthorizationException("forbidden")
+            if (principal.roles.any { it.code == RoleCode.HEAD_MANAGER } && call.request.httpMethod.isWrite()) {
+                throw AuthorizationException("read_only")
+            }
+        }
+        build()
+    }
+}

--- a/core-security/src/main/kotlin/com/example/bot/security/rbac/RoleAssignment.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/rbac/RoleAssignment.kt
@@ -1,0 +1,12 @@
+package com.example.bot.security.rbac
+
+/**
+ * Represents a role assigned to a user with a particular scope.
+ *
+ * @property code the role code
+ * @property scope scope of the role
+ */
+data class RoleAssignment(
+    val code: RoleCode,
+    val scope: Scope,
+)

--- a/core-security/src/main/kotlin/com/example/bot/security/rbac/RoleCache.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/rbac/RoleCache.kt
@@ -1,0 +1,41 @@
+package com.example.bot.security.rbac
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Simple in-memory cache for role assignments with a fixed TTL.
+ */
+class RoleCache(
+    private val repository: RoleRepository,
+    private val ttl: Duration = Duration.ofSeconds(60),
+) {
+    private data class Cached(
+        val roles: Set<RoleAssignment>,
+        val expiresAt: Instant,
+    )
+
+    private val cache = ConcurrentHashMap<Long, Cached>()
+
+    /**
+     * Returns role assignments for a user, loading from repository if cache entry expired.
+     */
+    suspend fun rolesFor(userId: Long): Set<RoleAssignment> {
+        val now = Instant.now()
+        val existing = cache[userId]
+        if (existing != null && existing.expiresAt.isAfter(now)) {
+            return existing.roles
+        }
+        val loaded = repository.findRoles(userId)
+        cache[userId] = Cached(loaded, now.plus(ttl))
+        return loaded
+    }
+
+    /**
+     * Invalidates cached roles for the given user.
+     */
+    fun invalidate(userId: Long) {
+        cache.remove(userId)
+    }
+}

--- a/core-security/src/main/kotlin/com/example/bot/security/rbac/RoleCode.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/rbac/RoleCode.kt
@@ -1,0 +1,15 @@
+package com.example.bot.security.rbac
+
+/**
+ * Enumeration of all supported roles in the system.
+ */
+enum class RoleCode {
+    OWNER,
+    GLOBAL_ADMIN,
+    HEAD_MANAGER,
+    CLUB_ADMIN,
+    MANAGER,
+    ENTRY_MANAGER,
+    PROMOTER,
+    GUEST,
+}

--- a/core-security/src/main/kotlin/com/example/bot/security/rbac/RoleRepository.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/rbac/RoleRepository.kt
@@ -1,0 +1,11 @@
+package com.example.bot.security.rbac
+
+/**
+ * Repository capable of loading role assignments for a user.
+ */
+interface RoleRepository {
+    /**
+     * Loads all role assignments for the given user identifier.
+     */
+    suspend fun findRoles(userId: Long): Set<RoleAssignment>
+}

--- a/core-security/src/main/kotlin/com/example/bot/security/rbac/Scope.kt
+++ b/core-security/src/main/kotlin/com/example/bot/security/rbac/Scope.kt
@@ -1,0 +1,12 @@
+package com.example.bot.security.rbac
+
+/**
+ * Scope of a role assignment.
+ */
+sealed class Scope {
+    /** Global scope grants rights across all clubs. */
+    data object Global : Scope()
+
+    /** Club scope restricts rights to a particular club. */
+    data class Club(val clubId: Long) : Scope()
+}

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     testImplementation(libs.kotest.runner)
     testImplementation(libs.kotest.assertions)
     testImplementation(libs.mockk)
+    testImplementation(libs.ktor.server.tests)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor"
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
+ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
+ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
 ktor-server-tests = { module = "io.ktor:ktor-server-tests-jvm", version.ref = "ktor" }
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }


### PR DESCRIPTION
## Summary
- add RBAC data structures and in-memory role cache
- wire stub security plugins and example secured routes
- include Telegram init data validator skeleton

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68bbb3b1b31c8321baeabf0d32d3af6a