### PR TITLE
Add basic confirmation and payment stubs

### DIFF
--- a/core-data/src/main/kotlin/com/example/bot/data/repo/PaymentsRepository.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/repo/PaymentsRepository.kt
@@ -1,0 +1,26 @@
+package com.example.bot.data.repo
+
+import com.example.bot.booking.InvoiceInfo
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Repository for storing invoices and payment records.
+ */
+interface PaymentsRepository {
+    suspend fun save(invoice: InvoiceInfo, idempotencyKey: String)
+    suspend fun findByIdempotencyKey(idempotencyKey: String): InvoiceInfo?
+}
+
+/**
+ * In-memory implementation used in tests.
+ */
+class InMemoryPaymentsRepository : PaymentsRepository {
+    private val byKey = ConcurrentHashMap<String, InvoiceInfo>()
+
+    override suspend fun save(invoice: InvoiceInfo, idempotencyKey: String) {
+        byKey.putIfAbsent(idempotencyKey, invoice)
+    }
+
+    override suspend fun findByIdempotencyKey(idempotencyKey: String): InvoiceInfo? = byKey[idempotencyKey]
+}
+

--- a/core-domain/src/main/kotlin/com/example/bot/booking/BookingServiceConfirm.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/booking/BookingServiceConfirm.kt
@@ -1,0 +1,36 @@
+package com.example.bot.booking
+
+import com.example.bot.payments.PaymentsService
+
+/**
+ * Starts booking confirmation flow with optional payment requirement.
+ */
+suspend fun BookingService.startConfirmation(
+    input: ConfirmInput,
+    contact: ContactInfo?,
+    policy: PaymentPolicy,
+    idemKey: String,
+): Either<BookingError, ConfirmResult> =
+    when (policy.mode) {
+        PaymentMode.NONE -> {
+            val req = ConfirmRequest(
+                holdId = null,
+                clubId = input.clubId,
+                eventStartUtc = input.eventStartUtc,
+                tableId = input.tableId,
+                guestsCount = input.guestsCount,
+                guestUserId = null,
+                guestName = contact?.tgUsername,
+                phoneE164 = contact?.phoneE164,
+            )
+            when (val res = confirm(req, idemKey)) {
+                is Either.Left -> Either.Left(res.value)
+                is Either.Right -> Either.Right(ConfirmResult.Confirmed(res.value))
+            }
+        }
+        PaymentMode.PROVIDER_DEPOSIT, PaymentMode.STARS_DIGITAL -> {
+            val invoice = PaymentsService.createInvoice(input, policy, idemKey)
+            Either.Right(ConfirmResult.PendingPayment(invoice))
+        }
+    }
+

--- a/core-domain/src/main/kotlin/com/example/bot/booking/ConfirmModels.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/booking/ConfirmModels.kt
@@ -1,0 +1,46 @@
+package com.example.bot.booking
+
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Input parameters for starting booking confirmation.
+ */
+data class ConfirmInput(
+    val clubId: Long,
+    val eventStartUtc: Instant,
+    val tableId: Long,
+    val tableNumber: Int,
+    val guestsCount: Int,
+    val minDeposit: BigDecimal,
+)
+
+/**
+ * Contact details supplied by the guest.
+ */
+data class ContactInfo(
+    val tgUsername: String?,
+    val phoneE164: String?,
+)
+
+/**
+ * Information about a generated invoice.
+ */
+data class InvoiceInfo(
+    val invoiceId: String,
+    val payload: String,
+    val totalMinor: Int,
+    val currency: String,
+    val startParameter: String,
+    val createLink: String? = null,
+)
+
+/** Result of confirmation attempt. */
+sealed interface ConfirmResult {
+    /** Confirmation is pending payment; [invoice] should be sent to user. */
+    data class PendingPayment(val invoice: InvoiceInfo) : ConfirmResult
+
+    /** Booking has been confirmed immediately. */
+    data class Confirmed(val booking: BookingSummary) : ConfirmResult
+}
+

--- a/core-domain/src/main/kotlin/com/example/bot/booking/PaymentPolicy.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/booking/PaymentPolicy.kt
@@ -1,0 +1,29 @@
+package com.example.bot.booking
+
+/**
+ * Mode of payment for a booking confirmation.
+ */
+enum class PaymentMode {
+    /** Booking requires no upfront payment. */
+    NONE,
+
+    /** Deposit should be charged via external provider. */
+    PROVIDER_DEPOSIT,
+
+    /** Digital add-ons are paid using Telegram Stars. */
+    STARS_DIGITAL,
+}
+
+/**
+ * Policy describing how payment should be handled.
+ *
+ * @property mode mode of payment
+ * @property currency ISO 4217 currency code or "XTR" for stars
+ * @property splitPay whether invoice supports split payment
+ */
+data class PaymentPolicy(
+    val mode: PaymentMode,
+    val currency: String = "RUB",
+    val splitPay: Boolean = true,
+)
+

--- a/core-domain/src/main/kotlin/com/example/bot/payments/PaymentsService.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/payments/PaymentsService.kt
@@ -1,0 +1,32 @@
+package com.example.bot.payments
+
+import com.example.bot.booking.ConfirmInput
+import com.example.bot.booking.InvoiceInfo
+import com.example.bot.booking.PaymentMode
+import com.example.bot.booking.PaymentPolicy
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Simple factory for generating invoice information used in tests.
+ */
+object PaymentsService {
+    /**
+     * Creates invoice based on provided [input] and [policy].
+     */
+    suspend fun createInvoice(input: ConfirmInput, policy: PaymentPolicy, idemKey: String): InvoiceInfo {
+        val total = input.minDeposit.multiply(BigDecimal(input.guestsCount))
+        val id = UUID.randomUUID().toString()
+        val currency = if (policy.mode == PaymentMode.STARS_DIGITAL) "XTR" else policy.currency
+        val totalMinor = total.multiply(BigDecimal(100)).toInt()
+        return InvoiceInfo(
+            invoiceId = id,
+            payload = idemKey,
+            totalMinor = totalMinor,
+            currency = currency,
+            startParameter = id.take(8),
+            createLink = if (policy.splitPay) null else null,
+        )
+    }
+}
+

--- a/core-testing/src/test/kotlin/com/example/bot/booking/BookingStartConfirmationTest.kt
+++ b/core-testing/src/test/kotlin/com/example/bot/booking/BookingStartConfirmationTest.kt
@@ -1,0 +1,41 @@
+package com.example.bot.booking
+
+import com.example.bot.data.booking.InMemoryBookingRepository
+import com.example.bot.data.outbox.InMemoryOutboxService
+import com.example.bot.booking.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+import java.time.Instant
+
+class BookingStartConfirmationTest : StringSpec({
+    "start confirmation returns invoice when payment required" {
+        val repo = InMemoryBookingRepository()
+        val outbox = InMemoryOutboxService()
+        val service = BookingService(repo, repo, outbox)
+        val event = EventDto(1, 1, Instant.parse("2025-01-01T20:00:00Z"), Instant.parse("2025-01-01T23:00:00Z"))
+        val table = TableDto(1, 10, 4, BigDecimal("10"), true)
+        repo.seed(event, table)
+        val input = ConfirmInput(1, event.startUtc, table.id, table.number, 2, table.minDeposit)
+        val policy = PaymentPolicy(PaymentMode.PROVIDER_DEPOSIT)
+        val result = service.startConfirmation(input, null, policy, "idem1")
+        val pending = (result as Either.Right).value as ConfirmResult.PendingPayment
+        pending.invoice.currency shouldBe "RUB"
+        pending.invoice.totalMinor shouldBe 2000
+    }
+
+    "start confirmation with none confirms immediately" {
+        val repo = InMemoryBookingRepository()
+        val outbox = InMemoryOutboxService()
+        val service = BookingService(repo, repo, outbox)
+        val event = EventDto(1, 1, Instant.parse("2025-01-01T20:00:00Z"), Instant.parse("2025-01-01T23:00:00Z"))
+        val table = TableDto(1, 10, 4, BigDecimal("10"), true)
+        repo.seed(event, table)
+        val input = ConfirmInput(1, event.startUtc, table.id, table.number, 2, table.minDeposit)
+        val policy = PaymentPolicy(PaymentMode.NONE)
+        val result = service.startConfirmation(input, null, policy, "idem2")
+        val booking = (result as Either.Right).value as ConfirmResult.Confirmed
+        booking.booking.status shouldBe "CONFIRMED"
+    }
+})
+


### PR DESCRIPTION
## Summary
- introduce models for confirmation flow and invoices
- add payment policy and invoice factory service
- implement startConfirmation extension with invoice generation
- provide in-memory payments repository and tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68bcb9d7b8c08321a35d7838a07ec04b