### PR TITLE
feat: add notification tables and outbox

### DIFF
--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -1,13 +1,24 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
+    id("org.flywaydb.flyway") version "10.16.0"
+}
+
+flyway {
+    url = System.getenv("DB_URL") ?: "jdbc:postgresql://localhost:5432/postgres"
+    user = System.getenv("DB_USER") ?: "postgres"
+    password = System.getenv("DB_PASSWORD") ?: "postgres"
+    locations = arrayOf("filesystem:${'$'}{projectDir}/src/main/resources/db/migration")
 }
 
 dependencies {
+    val exposedVersion = libs.versions.exposed.get()
     implementation(projects.coreDomain)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)
+    implementation("org.jetbrains.exposed:exposed-json:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
     implementation(libs.hikari)
     implementation(libs.flyway)
     implementation(libs.postgres)

--- a/core-data/src/main/kotlin/com/example/bot/data/notifications/Repositories.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/notifications/Repositories.kt
@@ -1,0 +1,182 @@
+package com.example.bot.data.notifications
+
+import kotlinx.serialization.json.JsonElement
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.isNull
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import java.time.OffsetDateTime
+
+data class NotifySegment(
+    val id: Long,
+    val title: String,
+    val definition: JsonElement,
+    val createdBy: Long,
+    val createdAt: OffsetDateTime
+)
+
+class NotifySegmentsRepository(private val db: Database) {
+    suspend fun insert(title: String, definition: JsonElement, createdBy: Long): Long =
+        newSuspendedTransaction(db = db) {
+            NotifySegments.insert {
+                it[NotifySegments.title] = title
+                it[NotifySegments.definition] = definition
+                it[NotifySegments.createdBy] = createdBy
+            }[NotifySegments.id]
+        }
+
+    suspend fun find(id: Long): NotifySegment? = newSuspendedTransaction(db = db) {
+        NotifySegments.select { NotifySegments.id eq id }
+            .map { toSegment(it) }
+            .singleOrNull()
+    }
+
+    private fun toSegment(row: ResultRow): NotifySegment = NotifySegment(
+        id = row[NotifySegments.id],
+        title = row[NotifySegments.title],
+        definition = row[NotifySegments.definition],
+        createdBy = row[NotifySegments.createdBy],
+        createdAt = row[NotifySegments.createdAt]
+    )
+}
+
+data class NotifyCampaign(
+    val id: Long,
+    val title: String,
+    val status: String,
+    val kind: String,
+    val clubId: Long?,
+    val messageThreadId: Int?,
+    val segmentId: Long?,
+    val scheduleCron: String?,
+    val startsAt: OffsetDateTime?,
+    val createdBy: Long,
+    val createdAt: OffsetDateTime,
+    val updatedAt: OffsetDateTime
+)
+
+class NotifyCampaignsRepository(private val db: Database) {
+    suspend fun insert(campaign: NotifyCampaign): Long =
+        newSuspendedTransaction(db = db) {
+            NotifyCampaigns.insert {
+                it[NotifyCampaigns.title] = campaign.title
+                it[NotifyCampaigns.status] = campaign.status
+                it[NotifyCampaigns.kind] = campaign.kind
+                it[NotifyCampaigns.clubId] = campaign.clubId
+                it[NotifyCampaigns.messageThreadId] = campaign.messageThreadId
+                it[NotifyCampaigns.segmentId] = campaign.segmentId
+                it[NotifyCampaigns.scheduleCron] = campaign.scheduleCron
+                it[NotifyCampaigns.startsAt] = campaign.startsAt
+                it[NotifyCampaigns.createdBy] = campaign.createdBy
+            }[NotifyCampaigns.id]
+        }
+
+    suspend fun find(id: Long): NotifyCampaign? = newSuspendedTransaction(db = db) {
+        NotifyCampaigns.select { NotifyCampaigns.id eq id }
+            .map { toCampaign(it) }
+            .singleOrNull()
+    }
+
+    private fun toCampaign(row: ResultRow): NotifyCampaign = NotifyCampaign(
+        id = row[NotifyCampaigns.id],
+        title = row[NotifyCampaigns.title],
+        status = row[NotifyCampaigns.status],
+        kind = row[NotifyCampaigns.kind],
+        clubId = row[NotifyCampaigns.clubId],
+        messageThreadId = row[NotifyCampaigns.messageThreadId],
+        segmentId = row[NotifyCampaigns.segmentId],
+        scheduleCron = row[NotifyCampaigns.scheduleCron],
+        startsAt = row[NotifyCampaigns.startsAt],
+        createdBy = row[NotifyCampaigns.createdBy],
+        createdAt = row[NotifyCampaigns.createdAt],
+        updatedAt = row[NotifyCampaigns.updatedAt]
+    )
+}
+
+data class UserSubscription(
+    val userId: Long,
+    val clubId: Long?,
+    val topic: String,
+    val optIn: Boolean,
+    val lang: String
+)
+
+class UserSubscriptionsRepository(private val db: Database) {
+    suspend fun insert(sub: UserSubscription) = newSuspendedTransaction(db = db) {
+        UserSubscriptions.insert {
+            it[UserSubscriptions.userId] = sub.userId
+            it[UserSubscriptions.clubId] = sub.clubId
+            it[UserSubscriptions.topic] = sub.topic
+            it[UserSubscriptions.optIn] = sub.optIn
+            it[UserSubscriptions.lang] = sub.lang
+        }
+    }
+
+    suspend fun find(userId: Long, clubId: Long?, topic: String): UserSubscription? =
+        newSuspendedTransaction(db = db) {
+            UserSubscriptions
+                .select {
+                    (UserSubscriptions.userId eq userId) and
+                        (UserSubscriptions.topic eq topic) and
+                        (clubId?.let { UserSubscriptions.clubId eq it } ?: UserSubscriptions.clubId.isNull())
+                }
+                .map { toSubscription(it) }
+                .singleOrNull()
+        }
+
+    private fun toSubscription(row: ResultRow): UserSubscription = UserSubscription(
+        userId = row[UserSubscriptions.userId],
+        clubId = row[UserSubscriptions.clubId],
+        topic = row[UserSubscriptions.topic],
+        optIn = row[UserSubscriptions.optIn],
+        lang = row[UserSubscriptions.lang]
+    )
+}
+
+data class OutboxRecord(
+    val id: Long,
+    val recipientType: String,
+    val recipientId: Long,
+    val dedupKey: String?,
+    val priority: Int,
+    val campaignId: Long?,
+    val method: String,
+    val payload: JsonElement,
+    val createdAt: OffsetDateTime
+)
+
+class NotificationsOutboxRepository(private val db: Database) {
+    suspend fun insert(record: OutboxRecord) = newSuspendedTransaction(db = db) {
+        NotificationsOutbox.insert {
+            it[NotificationsOutbox.recipientType] = record.recipientType
+            it[NotificationsOutbox.recipientId] = record.recipientId
+            it[NotificationsOutbox.dedupKey] = record.dedupKey
+            it[NotificationsOutbox.priority] = record.priority
+            it[NotificationsOutbox.campaignId] = record.campaignId
+            it[NotificationsOutbox.method] = record.method
+            it[NotificationsOutbox.payload] = record.payload
+        }
+    }
+
+    suspend fun find(id: Long): OutboxRecord? = newSuspendedTransaction(db = db) {
+        NotificationsOutbox.select { NotificationsOutbox.id eq id }
+            .map { toOutbox(it) }
+            .singleOrNull()
+    }
+
+    private fun toOutbox(row: ResultRow): OutboxRecord = OutboxRecord(
+        id = row[NotificationsOutbox.id],
+        recipientType = row[NotificationsOutbox.recipientType],
+        recipientId = row[NotificationsOutbox.recipientId],
+        dedupKey = row[NotificationsOutbox.dedupKey],
+        priority = row[NotificationsOutbox.priority],
+        campaignId = row[NotificationsOutbox.campaignId],
+        method = row[NotificationsOutbox.method],
+        payload = row[NotificationsOutbox.payload],
+        createdAt = row[NotificationsOutbox.createdAt]
+    )
+}

--- a/core-data/src/main/kotlin/com/example/bot/data/notifications/Tables.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/notifications/Tables.kt
@@ -1,0 +1,71 @@
+package com.example.bot.data.notifications
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+import org.jetbrains.exposed.sql.json.jsonb
+
+object NotifySegments : Table("notify_segments") {
+    val id = long("id").autoIncrement()
+    val title = text("title")
+    val definition = jsonb<JsonElement>("definition", Json)
+    val createdBy = long("created_by")
+    val createdAt = timestampWithTimeZone("created_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object NotifyCampaigns : Table("notify_campaigns") {
+    val id = long("id").autoIncrement()
+    val title = text("title")
+    val status = text("status")
+    val kind = text("kind")
+    val clubId = long("club_id").nullable()
+    val messageThreadId = integer("message_thread_id").nullable()
+    val segmentId = long("segment_id").nullable()
+    val scheduleCron = text("schedule_cron").nullable()
+    val startsAt = timestampWithTimeZone("starts_at").nullable()
+    val createdBy = long("created_by")
+    val createdAt = timestampWithTimeZone("created_at")
+    val updatedAt = timestampWithTimeZone("updated_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object UserSubscriptions : Table("user_subscriptions") {
+    val userId = long("user_id")
+    val clubId = long("club_id").nullable()
+    val topic = text("topic")
+    val optIn = bool("opt_in").default(true)
+    val lang = text("lang").default("ru")
+    override val primaryKey = PrimaryKey(userId, clubId, topic)
+}
+
+object NotificationsOutbox : Table("notifications_outbox") {
+    val id = long("id").autoIncrement()
+    val clubId = long("club_id").nullable()
+    val targetChatId = long("target_chat_id")
+    val messageThreadId = integer("message_thread_id").nullable()
+    val kind = text("kind")
+    val payload = jsonb<JsonElement>("payload", Json)
+    val status = text("status")
+    val attempts = integer("attempts").default(0)
+    val nextRetryAt = timestampWithTimeZone("next_retry_at").nullable()
+    val lastError = text("last_error").nullable()
+    val recipientType = text("recipient_type")
+    val recipientId = long("recipient_id")
+    val dedupKey = text("dedup_key").nullable().uniqueIndex()
+    val priority = integer("priority").default(100)
+    val campaignId = long("campaign_id").nullable()
+    val method = text("method")
+    val parseMode = text("parse_mode").nullable()
+    val attachments = jsonb<JsonElement>("attachments", Json).nullable()
+    val language = text("language").nullable()
+    val createdAt = timestampWithTimeZone("created_at")
+    override val primaryKey = PrimaryKey(id)
+
+    init {
+        index("idx_notifications_outbox_status_retry", false, status, nextRetryAt)
+        index("idx_notifications_outbox_campaign_id", false, campaignId)
+        index("idx_notifications_outbox_priority_created_at", false, priority, createdAt)
+    }
+}

--- a/core-data/src/main/resources/db/migration/V3__notify_init.sql
+++ b/core-data/src/main/resources/db/migration/V3__notify_init.sql
@@ -1,0 +1,71 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE notify_segments (
+    id BIGSERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    definition JSONB NOT NULL,
+    created_by BIGINT NOT NULL REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE notify_segments IS 'User targeting segments';
+COMMENT ON COLUMN notify_segments.definition IS 'Segment definition as JSON';
+COMMENT ON COLUMN notify_segments.created_by IS 'Author user id';
+
+CREATE TABLE notify_campaigns (
+    id BIGSERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('DRAFT','SCHEDULED','SENDING','PAUSED','DONE','FAILED')),
+    kind TEXT NOT NULL,
+    club_id BIGINT NULL REFERENCES clubs(id),
+    message_thread_id INT NULL,
+    segment_id BIGINT NULL REFERENCES notify_segments(id),
+    schedule_cron TEXT NULL,
+    starts_at TIMESTAMPTZ NULL,
+    created_by BIGINT NOT NULL REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE notify_campaigns IS 'Notification campaigns';
+COMMENT ON COLUMN notify_campaigns.status IS 'Campaign status';
+COMMENT ON COLUMN notify_campaigns.schedule_cron IS 'Cron schedule expression';
+COMMENT ON COLUMN notify_campaigns.starts_at IS 'Scheduled start in UTC';
+COMMENT ON COLUMN notify_campaigns.segment_id IS 'Target segment';
+
+CREATE TABLE user_subscriptions (
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    club_id BIGINT NULL REFERENCES clubs(id),
+    topic TEXT NOT NULL,
+    opt_in BOOLEAN NOT NULL DEFAULT TRUE,
+    lang TEXT NOT NULL DEFAULT 'ru',
+    PRIMARY KEY (user_id, club_id, topic)
+);
+COMMENT ON TABLE user_subscriptions IS 'User notification preferences';
+COMMENT ON COLUMN user_subscriptions.opt_in IS 'Whether user opted in';
+COMMENT ON COLUMN user_subscriptions.lang IS 'Preferred language';
+
+ALTER TABLE notifications_outbox
+    ADD COLUMN recipient_type TEXT NOT NULL,
+    ADD COLUMN recipient_id BIGINT NOT NULL,
+    ADD COLUMN dedup_key TEXT UNIQUE,
+    ADD COLUMN priority INT NOT NULL DEFAULT 100,
+    ADD COLUMN campaign_id BIGINT NULL REFERENCES notify_campaigns(id),
+    ADD COLUMN method TEXT NOT NULL,
+    ADD COLUMN parse_mode TEXT NULL,
+    ADD COLUMN attachments JSONB NULL,
+    ADD COLUMN language TEXT NULL,
+    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+COMMENT ON COLUMN notifications_outbox.recipient_type IS 'Target entity type';
+COMMENT ON COLUMN notifications_outbox.recipient_id IS 'Target entity id';
+COMMENT ON COLUMN notifications_outbox.dedup_key IS 'Unique key to deduplicate notifications';
+COMMENT ON COLUMN notifications_outbox.priority IS 'Lower values are processed first';
+COMMENT ON COLUMN notifications_outbox.campaign_id IS 'Related notify_campaigns.id';
+COMMENT ON COLUMN notifications_outbox.method IS 'Delivery method';
+COMMENT ON COLUMN notifications_outbox.parse_mode IS 'Message parse mode';
+COMMENT ON COLUMN notifications_outbox.attachments IS 'Optional attachments data';
+COMMENT ON COLUMN notifications_outbox.language IS 'Preferred language';
+COMMENT ON COLUMN notifications_outbox.created_at IS 'Record creation time';
+
+CREATE INDEX IF NOT EXISTS idx_notifications_outbox_status_retry ON notifications_outbox(status, next_retry_at);
+CREATE INDEX idx_notifications_outbox_campaign_id ON notifications_outbox(campaign_id);
+CREATE INDEX idx_notifications_outbox_priority_created_at ON notifications_outbox(priority, created_at);


### PR DESCRIPTION
## Summary
- add notify_segments, notify_campaigns, user_subscriptions
- extend notifications_outbox with routing and metadata
- provide Exposed models and simple repositories

## Testing
- `./gradlew :core-data:compileKotlin --exclude-task :app-bot:compileKotlin`
- `DB_URL=jdbc:postgresql://localhost:5432/postgres DB_USER=postgres DB_PASSWORD=postgres ./gradlew flywayMigrate` *(fails: org/gradle/api/plugins/JavaPluginConvention)*


------
https://chatgpt.com/codex/tasks/task_e_68be947c9ae48321ac9e0911b7c88e55