### PR TITLE
feat: add notification templates and models

### DIFF
--- a/core-domain/src/main/kotlin/com/example/bot/notifications/NotifyModels.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/notifications/NotifyModels.kt
@@ -1,0 +1,52 @@
+package com.example.bot.notifications
+
+// Domain events that may trigger notifications
+sealed interface TxEvent {
+    data class BookingCreated(val bookingId: String) : TxEvent
+    data class BookingCancelled(val bookingId: String) : TxEvent
+    data class BookingSeated(val bookingId: String) : TxEvent
+    data class GuestArrived(val guestId: String) : TxEvent
+    data class GuestDenied(val guestId: String) : TxEvent
+    data class GuestLate(val guestId: String) : TxEvent
+    data class QuestionFromUser(val userId: String, val question: String) : TxEvent
+}
+
+// Notification send method
+enum class NotifyMethod {
+    TEXT,
+    PHOTO,
+    ALBUM
+}
+
+// Simplified parse modes for outgoing messages
+enum class ParseMode {
+    MARKDOWNV2,
+    HTML
+}
+
+// Simple representation of media for albums
+// type can be "photo", "video", etc.
+data class MediaItem(
+    val type: String,
+    val url: String,
+    val caption: String? = null,
+    val parseMode: ParseMode? = null
+)
+
+// Minimal keyboard specification: rows of button labels
+data class InlineKeyboardSpec(val rows: List<List<String>>)
+
+// Unified notification message
+// Depending on method, text/photoUrl/album are used
+// parseMode applies to text or captions where relevant
+data class NotifyMessage(
+    val chatId: Long,
+    val messageThreadId: Int?,
+    val method: NotifyMethod,
+    val text: String?,
+    val parseMode: ParseMode?,
+    val photoUrl: String?,
+    val album: List<MediaItem>?,
+    val buttons: InlineKeyboardSpec?,
+    val dedupKey: String?
+)

--- a/core-domain/src/main/kotlin/com/example/bot/notifications/NotifyTemplates.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/notifications/NotifyTemplates.kt
@@ -1,0 +1,36 @@
+package com.example.bot.notifications
+
+/** Escape text for safe HTML display. */
+fun escapeHtml(text: String): String = buildString {
+    text.forEach { ch ->
+        when (ch) {
+            '<' -> append("&lt;")
+            '>' -> append("&gt;")
+            '&' -> append("&amp;")
+            '"' -> append("&quot;")
+            else -> append(ch)
+        }
+    }
+}
+
+private val mdv2SpecialChars = setOf('_', '*', '[', ']', '(', ')', '~', '\\', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!', '`')
+
+/** Escape text for safe MarkdownV2 display. */
+fun escapeMdV2(text: String): String = buildString {
+    text.forEach { ch ->
+        if (mdv2SpecialChars.contains(ch)) append('\\')
+        append(ch)
+    }
+}
+
+fun tmplBookingCreatedRU(name: String): String = "\u2705 Бронь создана: ${escapeMdV2(name)}"
+fun tmplBookingCreatedEN(name: String): String = "\u2705 Booking created: ${escapeMdV2(name)}"
+
+fun tmplGuestArrivedRU(name: String): String = "\uD83C\uDF89 Гость ${escapeMdV2(name)} прибыл"
+fun tmplGuestArrivedEN(name: String): String = "\uD83C\uDF89 Guest ${escapeMdV2(name)} arrived"
+
+fun tmplAfishaRU(title: String): String = "<b>${escapeHtml(title)}</b>"
+fun tmplAfishaEN(title: String): String = "<b>${escapeHtml(title)}</b>"
+
+fun tmplReminderRU(text: String): String = "Напоминание: ${escapeMdV2(text)}"
+fun tmplReminderEN(text: String): String = "Reminder: ${escapeMdV2(text)}"

--- a/core-domain/src/test/kotlin/com/example/bot/notifications/TemplatesSafetyTest.kt
+++ b/core-domain/src/test/kotlin/com/example/bot/notifications/TemplatesSafetyTest.kt
@@ -1,0 +1,25 @@
+package com.example.bot.notifications
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TemplatesSafetyTest {
+    @Test
+    fun `markdown special characters are escaped`() {
+        val special = "_*[]()~\\>#+-=|{}.!`"
+        val escaped = escapeMdV2(special)
+        val expected = "\\_\\*\\[\\]\\(\\)\\~\\\\\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!\\`"
+        assertEquals(expected, escaped)
+        assertEquals("\u2705 Booking created: $expected", tmplBookingCreatedEN(special))
+        assertEquals("Напоминание: $expected", tmplReminderRU(special))
+    }
+
+    @Test
+    fun `html special characters are escaped`() {
+        val special = "<tag>\"&"
+        val escaped = escapeHtml(special)
+        val expected = "&lt;tag&gt;&quot;&amp;"
+        assertEquals(expected, escaped)
+        assertEquals("<b>$expected</b>", tmplAfishaEN(special))
+    }
+}


### PR DESCRIPTION
## Summary
- add notification domain models and message envelope
- implement safe MarkdownV2/HTML templates with escaping helpers
- cover templates with safety tests

## Testing
- `./gradlew :core-domain:test`


------
https://chatgpt.com/codex/tasks/task_e_68be983f24b883219ed1c18c86e8e822