### PR TITLE
Add notification outbox repository and worker

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/workers/OutboxWorker.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/workers/OutboxWorker.kt
@@ -1,0 +1,118 @@
+package com.example.bot.workers
+
+import com.example.bot.data.repo.OutboxRepository
+import com.example.bot.notifications.NotifyMethod
+import com.example.bot.notifications.NotifyMessage
+import com.example.bot.notifications.ParseMode
+import com.example.bot.telegram.NotifySender
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import com.pengrad.telegrambot.model.request.Keyboard
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.time.OffsetDateTime
+import kotlin.math.pow
+
+/** Simple interface for token buckets. */
+interface TokenBucket {
+    suspend fun take()
+}
+
+class OutboxWorker(
+    private val scope: CoroutineScope,
+    private val repo: OutboxRepository,
+    private val sender: NotifySender,
+    private val globalBucket: TokenBucket,
+    private val chatBucket: (Long) -> TokenBucket,
+    private val workers: Int,
+    private val batchSize: Int = 10,
+) {
+
+    fun start() {
+        repeat(workers) {
+            scope.launch { run() }
+        }
+    }
+
+    private suspend fun run() {
+        while (scope.isActive) {
+            val batch = repo.pickBatch(OffsetDateTime.now(), batchSize)
+            if (batch.isEmpty()) {
+                delay(1000)
+                continue
+            }
+            for (rec in batch) {
+                process(rec)
+            }
+        }
+    }
+
+    private suspend fun process(rec: OutboxRepository.Record) {
+        val msg = rec.message
+        rec.dedupKey?.let {
+            if (repo.isSent(it)) {
+                repo.markSent(rec.id, null)
+                return
+            }
+        }
+        globalBucket.take()
+        chatBucket(msg.chatId).take()
+
+        val result = when (msg.method) {
+            NotifyMethod.TEXT -> sender.sendMessage(
+                msg.chatId,
+                msg.text.orEmpty(),
+                toTelegramParseMode(msg.parseMode),
+                msg.messageThreadId,
+                toKeyboard(msg),
+            )
+            NotifyMethod.PHOTO -> sender.sendPhoto(
+                msg.chatId,
+                NotifySender.PhotoContent.Url(requireNotNull(msg.photoUrl)),
+                msg.text,
+                toTelegramParseMode(msg.parseMode),
+                msg.messageThreadId,
+            )
+            NotifyMethod.ALBUM -> {
+                val media = msg.album.orEmpty().map {
+                    NotifySender.Media(
+                        content = NotifySender.PhotoContent.Url(it.url),
+                        caption = it.caption,
+                        parseMode = toTelegramParseMode(it.parseMode),
+                    )
+                }
+                sender.sendMediaGroup(msg.chatId, media, msg.messageThreadId)
+            }
+        }
+
+        when (result) {
+            NotifySender.Result.Ok -> repo.markSent(rec.id, null)
+            is NotifySender.Result.RetryAfter -> {
+                val next = OffsetDateTime.now().plusSeconds(result.seconds.toLong())
+                repo.markFailed(rec.id, "retry_after", next)
+            }
+            is NotifySender.Result.Failed -> {
+                val delaySec = 2.0.pow(rec.attempts.toDouble()).toLong().coerceAtLeast(1)
+                val next = OffsetDateTime.now().plusSeconds(delaySec)
+                repo.markFailed(rec.id, result.description, next)
+            }
+        }
+    }
+
+    private fun toTelegramParseMode(pm: ParseMode?): com.pengrad.telegrambot.model.request.ParseMode? =
+        when (pm) {
+            ParseMode.MARKDOWNV2 -> com.pengrad.telegrambot.model.request.ParseMode.MarkdownV2
+            ParseMode.HTML -> com.pengrad.telegrambot.model.request.ParseMode.HTML
+            null -> null
+        }
+
+    private fun toKeyboard(msg: NotifyMessage): Keyboard? = msg.buttons?.let { spec ->
+        val rows = spec.rows.map { row ->
+            row.map { text -> InlineKeyboardButton(text).callbackData(text) }.toTypedArray()
+        }.toTypedArray()
+        InlineKeyboardMarkup(*rows)
+    }
+}
+

--- a/core-data/src/main/kotlin/com/example/bot/data/repo/OutboxRepository.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/repo/OutboxRepository.kt
@@ -1,0 +1,109 @@
+package com.example.bot.data.repo
+
+import com.example.bot.data.notifications.NotificationsOutbox
+import com.example.bot.notifications.NotifyMessage
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.insertIgnore
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.Database
+import java.time.OffsetDateTime
+
+class OutboxRepository(private val db: Database) {
+
+    data class Record(
+        val id: Long,
+        val message: NotifyMessage,
+        val dedupKey: String?,
+        val attempts: Int,
+    )
+
+    private val json = Json
+
+    suspend fun enqueue(
+        msg: NotifyMessage,
+        campaignId: Long? = null,
+        priority: Int = 100,
+        dedupKey: String? = null,
+    ) = newSuspendedTransaction(db = db) {
+        NotificationsOutbox.insertIgnore {
+            it[targetChatId] = msg.chatId
+            it[messageThreadId] = msg.messageThreadId
+            it[kind] = msg.method.name
+            it[payload] = json.encodeToJsonElement(NotifyMessage.serializer(), msg)
+            it[status] = "PENDING"
+            it[nextRetryAt] = OffsetDateTime.now()
+            it[recipientType] = "chat"
+            it[recipientId] = msg.chatId
+            it[NotificationsOutbox.dedupKey] = dedupKey ?: msg.dedupKey
+            it[NotificationsOutbox.priority] = priority
+            it[NotificationsOutbox.campaignId] = campaignId
+            it[method] = msg.method.name
+            it[parseMode] = msg.parseMode?.name
+        }
+    }
+
+    suspend fun pickBatch(now: OffsetDateTime, limit: Int): List<Record> =
+        newSuspendedTransaction(db = db) {
+            NotificationsOutbox
+                .select {
+                    (NotificationsOutbox.status eq "PENDING") and
+                        (NotificationsOutbox.nextRetryAt lessEq now)
+                }
+                .orderBy(NotificationsOutbox.priority to SortOrder.ASC,
+                    NotificationsOutbox.createdAt to SortOrder.ASC)
+                .forUpdate()
+                .limit(limit)
+                .map {
+                    Record(
+                        id = it[NotificationsOutbox.id],
+                        message = json.decodeFromJsonElement(
+                            NotifyMessage.serializer(),
+                            it[NotificationsOutbox.payload],
+                        ),
+                        dedupKey = it[NotificationsOutbox.dedupKey],
+                        attempts = it[NotificationsOutbox.attempts],
+                    )
+                }
+        }
+
+    suspend fun markSent(id: Long, messageId: Long?) =
+        newSuspendedTransaction(db = db) {
+            NotificationsOutbox.update({ NotificationsOutbox.id eq id }) {
+                it[status] = "SENT"
+                it[lastError] = null
+                it[nextRetryAt] = null
+                with(org.jetbrains.exposed.sql.SqlExpressionBuilder) {
+                    it[attempts] = attempts + 1
+                }
+            }
+        }
+
+    suspend fun markFailed(id: Long, error: String?, nextRetryAt: OffsetDateTime) =
+        newSuspendedTransaction(db = db) {
+            NotificationsOutbox.update({ NotificationsOutbox.id eq id }) {
+                it[status] = "PENDING"
+                it[lastError] = error
+                it[NotificationsOutbox.nextRetryAt] = nextRetryAt
+                with(org.jetbrains.exposed.sql.SqlExpressionBuilder) {
+                    it[attempts] = attempts + 1
+                }
+            }
+        }
+
+    suspend fun isSent(dedupKey: String): Boolean =
+        newSuspendedTransaction(db = db) {
+            NotificationsOutbox
+                .select {
+                    (NotificationsOutbox.dedupKey eq dedupKey) and
+                        (NotificationsOutbox.status eq "SENT")
+                }
+                .empty().not()
+        }
+}
+

--- a/core-domain/src/main/kotlin/com/example/bot/notifications/NotifyModels.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/notifications/NotifyModels.kt
@@ -1,5 +1,7 @@
 package com.example.bot.notifications
 
+import kotlinx.serialization.Serializable
+
 // Domain events that may trigger notifications
 sealed interface TxEvent {
     data class BookingCreated(val bookingId: String) : TxEvent
@@ -12,33 +14,38 @@ sealed interface TxEvent {
 }
 
 // Notification send method
+@Serializable
 enum class NotifyMethod {
     TEXT,
     PHOTO,
-    ALBUM
+    ALBUM,
 }
 
 // Simplified parse modes for outgoing messages
+@Serializable
 enum class ParseMode {
     MARKDOWNV2,
-    HTML
+    HTML,
 }
 
 // Simple representation of media for albums
 // type can be "photo", "video", etc.
+@Serializable
 data class MediaItem(
     val type: String,
     val url: String,
     val caption: String? = null,
-    val parseMode: ParseMode? = null
+    val parseMode: ParseMode? = null,
 )
 
 // Minimal keyboard specification: rows of button labels
+@Serializable
 data class InlineKeyboardSpec(val rows: List<List<String>>)
 
 // Unified notification message
 // Depending on method, text/photoUrl/album are used
 // parseMode applies to text or captions where relevant
+@Serializable
 data class NotifyMessage(
     val chatId: Long,
     val messageThreadId: Int?,
@@ -48,5 +55,6 @@ data class NotifyMessage(
     val photoUrl: String?,
     val album: List<MediaItem>?,
     val buttons: InlineKeyboardSpec?,
-    val dedupKey: String?
+    val dedupKey: String?,
 )
+


### PR DESCRIPTION
## Summary
- add serializable notification models
- implement OutboxRepository with enqueue, batch pick and status updates
- create OutboxWorker with token bucket throttling and retry backoff

## Testing
- `./gradlew :core-data:test`
- `./gradlew :app-bot:test`


------
https://chatgpt.com/codex/tasks/task_e_68bee5a36974832188a749850d461869