### PR TITLE
Add test infrastructure and sample tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,26 @@ to that base URL instead of `https://api.telegram.org`.
 export $(grep -v '^#' .env | xargs)
 ./gradlew :app-bot:run
 ```
+
+## Testing
+
+Run the full test suite:
+
+```bash
+./gradlew test
+```
+
+Run only integration smoke tests:
+
+```bash
+./gradlew :core-testing:test --tests "*SmokeTest*"
+```
+
+Enable verbose logging:
+
+```bash
+./gradlew test -i
+```
+
+Test reports are generated under `build/reports/tests/test/index.html`.
+

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     testImplementation(libs.flyway)
     testImplementation(libs.exposed.core)
     testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.hikari)
+    testImplementation(libs.postgres)
     testImplementation(libs.ktor.serialization.kotlinx.json)
     testImplementation(libs.ktor.server.content.negotiation)
 }

--- a/core-testing/src/test/kotlin/com/example/availability/AvailabilityServiceTest.kt
+++ b/core-testing/src/test/kotlin/com/example/availability/AvailabilityServiceTest.kt
@@ -1,0 +1,54 @@
+package com.example.availability
+
+import com.example.bot.availability.AvailabilityRepository
+import com.example.bot.availability.AvailabilityService
+import com.example.bot.policy.CutoffPolicy
+import com.example.bot.time.Club
+import com.example.bot.time.ClubException
+import com.example.bot.time.ClubHoliday
+import com.example.bot.time.ClubHour
+import com.example.bot.time.Event
+import com.example.bot.time.OperatingRulesResolver
+import com.example.bot.availability.Table
+import java.time.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class AvailabilityServiceTest {
+    private class FakeRepo : AvailabilityRepository {
+        override suspend fun findClub(clubId: Long) = Club(clubId, "Europe/Berlin")
+        override suspend fun listClubHours(clubId: Long) = listOf(
+            ClubHour(DayOfWeek.FRIDAY, LocalTime.of(22, 0), LocalTime.of(6, 0)),
+            ClubHour(DayOfWeek.SATURDAY, LocalTime.of(22, 0), LocalTime.of(6, 0))
+        )
+        override suspend fun listHolidays(clubId: Long, from: LocalDate, to: LocalDate) = emptyList<ClubHoliday>()
+        override suspend fun listExceptions(clubId: Long, from: LocalDate, to: LocalDate) =
+            listOf(ClubException(LocalDate.of(2024, 3, 29), false, null, null))
+        override suspend fun listEvents(clubId: Long, from: Instant, to: Instant) = emptyList<Event>()
+        override suspend fun findEvent(clubId: Long, startUtc: Instant) = null
+        override suspend fun listTables(clubId: Long) = emptyList<Table>()
+        override suspend fun listActiveHoldTableIds(eventId: Long, now: Instant) = emptySet<Long>()
+        override suspend fun listActiveBookingTableIds(eventId: Long) = emptySet<Long>()
+    }
+
+    @Test
+    fun `should list upcoming nights skipping closed and handle DST`() = runTest {
+        val clock = Clock.fixed(Instant.parse("2024-03-28T12:00:00Z"), ZoneOffset.UTC)
+        val repo = FakeRepo()
+        val resolver = OperatingRulesResolver(repo, clock)
+        val service = AvailabilityService(repo, resolver, CutoffPolicy(), clock)
+
+        val nights = service.listOpenNights(1, limit = 2)
+        assertEquals(2, nights.size)
+
+        val first = nights[0]
+        assertEquals(LocalDateTime.of(2024, 3, 30, 22, 0), first.openLocal)
+        assertEquals(LocalDateTime.of(2024, 3, 31, 6, 0), first.closeLocal)
+        assertEquals(Duration.ofHours(7), Duration.between(first.eventStartUtc, first.eventEndUtc))
+
+        val second = nights[1]
+        assertEquals(LocalDateTime.of(2024, 4, 5, 22, 0), second.openLocal)
+        assertEquals(LocalDateTime.of(2024, 4, 6, 6, 0), second.closeLocal)
+    }
+}

--- a/core-testing/src/test/kotlin/com/example/ktor/RoutesSmokeTest.kt
+++ b/core-testing/src/test/kotlin/com/example/ktor/RoutesSmokeTest.kt
@@ -1,0 +1,40 @@
+package com.example.ktor
+
+import com.example.bot.observability.DefaultHealthService
+import com.example.bot.observability.MetricsProvider
+import com.example.bot.plugins.installMetrics
+import com.example.bot.routes.observabilityRoutes
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RoutesSmokeTest {
+    @Test
+    fun `health and metrics exposed`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            val registry = MetricsProvider.prometheusRegistry()
+            installMetrics(registry)
+            routing { observabilityRoutes(MetricsProvider(registry), DefaultHealthService()) }
+            registry.counter("custom.counter").increment()
+        }
+        val health = client.get("/health")
+        assertEquals(HttpStatusCode.OK, health.status)
+        val metrics = client.get("/metrics")
+        assertEquals(HttpStatusCode.OK, metrics.status)
+        val ctype = metrics.headers[HttpHeaders.ContentType]
+        assertTrue(ctype?.contains("text/plain") == true)
+        val body = metrics.bodyAsText()
+        assertTrue(body.contains("http_server_requests_seconds"))
+        assertTrue(body.contains("custom_counter"))
+    }
+}

--- a/core-testing/src/test/kotlin/com/example/notify/OutboxWorkerSmokeTest.kt
+++ b/core-testing/src/test/kotlin/com/example/notify/OutboxWorkerSmokeTest.kt
@@ -1,0 +1,63 @@
+package com.example.notify
+
+import com.example.bot.data.notifications.NotificationsOutbox
+import com.example.bot.data.repo.OutboxRepository
+import com.example.bot.notifications.NotifyConfig
+import com.example.bot.notifications.NotifyMessage
+import com.example.bot.notifications.NotifyMethod
+import com.example.bot.notifications.Permit
+import com.example.bot.notifications.RatePolicy
+import com.example.bot.notifications.TimeSource
+import com.example.bot.telegram.NotifySender
+import com.example.bot.workers.OutboxWorker
+import com.example.testing.support.DbSupport
+import com.example.testing.support.PgContainer
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class OutboxWorkerSmokeTest : PgContainer() {
+    @BeforeEach
+    fun prepare() {
+        DbSupport.resetAndMigrate(dataSource)
+    }
+
+    @Test
+    fun `should send all messages`() = runTest {
+        val repo = OutboxRepository(database)
+        val sender = mockk<NotifySender>()
+        coEvery { sender.sendMessage(any(), any(), any(), any(), any()) } returns NotifySender.Result.Ok
+        coEvery { sender.sendPhoto(any(), any(), any(), any(), any()) } returns NotifySender.Result.Ok
+        coEvery { sender.sendMediaGroup(any(), any(), any()) } returns NotifySender.Result.Ok
+        val policy = object : RatePolicy {
+            override val timeSource: TimeSource = object : TimeSource { override fun nowMs() = System.currentTimeMillis() }
+            override fun acquireGlobal(n: Int, now: Long) = Permit(true)
+            override fun acquireChat(chatId: Long, n: Int, now: Long) = Permit(true)
+            override fun on429(chatId: Long?, retryAfter: Long, now: Long) {}
+        }
+        val registry = SimpleMeterRegistry()
+        val config = NotifyConfig(workerParallelism = 1)
+
+        for (i in 1..10) {
+            repo.enqueue(NotifyMessage(i.toLong(), null, NotifyMethod.TEXT, "hi", null, null, null, null, null))
+        }
+
+        val worker = OutboxWorker(this, repo, sender, policy, config, registry)
+        worker.start()
+        advanceUntilIdle()
+
+        val sent = newSuspendedTransaction(db = database) {
+            NotificationsOutbox.select { NotificationsOutbox.status eq "SENT" }.count()
+        }
+        assertEquals(10, sent)
+        assertEquals(10.0, registry.counter("notify.sent", "method", "TEXT", "threaded", "false").count())
+    }
+}

--- a/core-testing/src/test/kotlin/com/example/payments/PaymentsServiceUnitTest.kt
+++ b/core-testing/src/test/kotlin/com/example/payments/PaymentsServiceUnitTest.kt
@@ -1,0 +1,63 @@
+package com.example.payments
+
+import com.example.bot.booking.BookingService
+import com.example.bot.booking.BookingSummary
+import com.example.bot.booking.Either
+import com.example.bot.booking.PaymentPolicy
+import com.example.bot.booking.payments.ConfirmInput
+import com.example.bot.booking.payments.ConfirmResult
+import com.example.bot.booking.payments.PaymentMode
+import com.example.bot.booking.payments.PaymentsService
+import com.example.bot.payments.PaymentConfig
+import com.example.bot.payments.PaymentsRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PaymentsServiceUnitTest {
+    private val bookingService = mockk<BookingService>()
+    private val repo = mockk<PaymentsRepository>(relaxed = true)
+    private val service = PaymentsService(bookingService, repo, PaymentConfig(providerToken = "token"))
+
+    @Test
+    fun `should create pending payment for provider deposit`() = runTest {
+        val input = ConfirmInput(1, Instant.parse("2024-03-01T00:00:00Z"), 1, 1, 2, BigDecimal(100))
+        val policy = PaymentPolicy(mode = PaymentMode.PROVIDER_DEPOSIT, currency = "RUB")
+        val res = service.startConfirmation(input, null, policy, "idem")
+        assertTrue(res is Either.Right)
+        val pending = res.value as ConfirmResult.PendingPayment
+        assertEquals(20000L, pending.invoice.totalMinor)
+        assertTrue(pending.invoice.payload.isNotBlank())
+        coVerify { repo.createInitiated(null, "PROVIDER", "RUB", 20000L, pending.invoice.payload, "idem") }
+    }
+
+    @Test
+    fun `should confirm without payment when mode none`() = runTest {
+        val summary = BookingSummary(UUID.randomUUID(), 1, 1, 1, 1, 1, BigDecimal(50), "CONFIRMED", Instant.now(), "qr")
+        coEvery { bookingService.confirm(any(), any()) } returns Either.Right(summary)
+        val input = ConfirmInput(1, Instant.now(), 1, 1, 1, BigDecimal(50))
+        val policy = PaymentPolicy(mode = PaymentMode.NONE)
+        val res = service.startConfirmation(input, null, policy, "idem2")
+        assertTrue(res is Either.Right)
+        val confirmed = res.value as ConfirmResult.Confirmed
+        assertEquals(summary, confirmed.booking)
+    }
+
+    @Test
+    fun `stars mode uses XTR currency`() = runTest {
+        val input = ConfirmInput(1, Instant.now(), 1, 1, 3, BigDecimal(1))
+        val policy = PaymentPolicy(mode = PaymentMode.STARS_DIGITAL)
+        val res = service.startConfirmation(input, null, policy, "idem3")
+        assertTrue(res is Either.Right)
+        val pending = res.value as ConfirmResult.PendingPayment
+        assertEquals("XTR", pending.invoice.currency)
+        coVerify { repo.createInitiated(null, "STARS", "XTR", 3L, pending.invoice.payload, "idem3") }
+    }
+}

--- a/core-testing/src/test/kotlin/com/example/testing/support/CoroutineTestExt.kt
+++ b/core-testing/src/test/kotlin/com/example/testing/support/CoroutineTestExt.kt
@@ -1,0 +1,34 @@
+package com.example.testing.support
+
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Helper around [runTest] to avoid using blocking calls in coroutine tests.
+ */
+fun runBlockingTest(block: suspend TestScope.() -> Unit) = runTest { block() }
+
+/**
+ * JUnit extension that fails a test if [forbiddenSleep] was invoked.
+ */
+class NoThreadSleepExtension : BeforeEachCallback, AfterEachCallback {
+    override fun beforeEach(context: ExtensionContext) { slept.set(false) }
+    override fun afterEach(context: ExtensionContext) {
+        if (slept.get()) {
+            throw AssertionError("Thread.sleep is not allowed in tests")
+        }
+    }
+    companion object { internal val slept = AtomicBoolean(false) }
+}
+
+/**
+ * Wrapper that marks usage of [Thread.sleep]; use only in rare cases.
+ */
+fun forbiddenSleep(millis: Long) {
+    NoThreadSleepExtension.slept.set(true)
+    Thread.sleep(millis)
+}

--- a/core-testing/src/test/kotlin/com/example/testing/support/DbSupport.kt
+++ b/core-testing/src/test/kotlin/com/example/testing/support/DbSupport.kt
@@ -1,0 +1,19 @@
+package com.example.testing.support
+
+import javax.sql.DataSource
+import org.flywaydb.core.Flyway
+import org.jetbrains.exposed.sql.Database
+
+/**
+ * Utility to reset database state and apply migrations before each test.
+ */
+object DbSupport {
+    private const val LOCATION = "classpath:db/migration"
+
+    fun resetAndMigrate(dataSource: DataSource): Database {
+        val flyway = Flyway.configure().dataSource(dataSource).locations(LOCATION).load()
+        flyway.clean()
+        flyway.migrate()
+        return Database.connect(dataSource)
+    }
+}

--- a/core-testing/src/test/kotlin/com/example/testing/support/FakeTimeSource.kt
+++ b/core-testing/src/test/kotlin/com/example/testing/support/FakeTimeSource.kt
@@ -1,0 +1,15 @@
+package com.example.testing.support
+
+import java.util.concurrent.atomic.AtomicLong
+
+/** Simple pluggable time source for tests. */
+interface TimeSource {
+    fun nowMs(): Long
+}
+
+class FakeTimeSource(startMs: Long = 0L) : TimeSource {
+    private val t = AtomicLong(startMs)
+    override fun nowMs(): Long = t.get()
+    fun advance(ms: Long) { t.addAndGet(ms) }
+    fun set(ms: Long) { t.set(ms) }
+}

--- a/core-testing/src/test/kotlin/com/example/testing/support/Fixtures.kt
+++ b/core-testing/src/test/kotlin/com/example/testing/support/Fixtures.kt
@@ -1,0 +1,38 @@
+package com.example.testing.support
+
+import com.example.bot.availability.Table
+import com.example.bot.domain.User
+import com.example.bot.notifications.NotifyMessage
+import com.example.bot.time.Club
+import com.example.bot.time.Event
+import java.time.Instant
+
+/** Factory helpers for test entities. */
+object Fixtures {
+    fun club(id: Long = 1, timezone: String = "UTC") = Club(id, timezone)
+
+    fun event(
+        id: Long = 1,
+        clubId: Long = 1,
+        start: Instant = Instant.now(),
+        end: Instant = start.plusSeconds(3600),
+        special: Boolean = true
+    ) = Event(id, clubId, start, end, special)
+
+    fun table(
+        id: Long = 1,
+        number: String = "T1",
+        zone: String = "A",
+        capacity: Int = 4,
+        minDeposit: Int = 100,
+        active: Boolean = true
+    ) = Table(id, number, zone, capacity, minDeposit, active)
+
+    fun user(id: Long = 1, name: String = "User", role: String = "guest") = User(id, name, role)
+
+    data class Promoter(val id: Long = 1, val name: String = "Promoter", val alias: String = "prom")
+    fun promoter(id: Long = 1, name: String = "Promoter", alias: String = "prom") = Promoter(id, name, alias)
+
+    fun notifyMessage(chatId: Long = 1, text: String = "hi") =
+        NotifyMessage(chatId, null, com.example.bot.notifications.NotifyMethod.TEXT, text, null, null, null, null, null)
+}

--- a/core-testing/src/test/kotlin/com/example/testing/support/LoggingTestAppender.kt
+++ b/core-testing/src/test/kotlin/com/example/testing/support/LoggingTestAppender.kt
@@ -1,0 +1,14 @@
+package com.example.testing.support
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+
+/**
+ * Logback appender collecting log messages for assertions.
+ */
+class LoggingTestAppender : AppenderBase<ILoggingEvent>() {
+    private val events = mutableListOf<ILoggingEvent>()
+    override fun append(eventObject: ILoggingEvent) { events += eventObject }
+    fun events(): List<ILoggingEvent> = events.toList()
+    fun clear() { events.clear() }
+}

--- a/core-testing/src/test/kotlin/com/example/testing/support/MetricsTestRegistry.kt
+++ b/core-testing/src/test/kotlin/com/example/testing/support/MetricsTestRegistry.kt
@@ -1,0 +1,8 @@
+package com.example.testing.support
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+
+/** Shared [SimpleMeterRegistry] for tests verifying metrics. */
+object MetricsTestRegistry {
+    val registry = SimpleMeterRegistry()
+}

--- a/core-testing/src/test/kotlin/com/example/testing/support/PgContainer.kt
+++ b/core-testing/src/test/kotlin/com/example/testing/support/PgContainer.kt
@@ -1,0 +1,46 @@
+package com.example.testing.support
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.sql.Database
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Base class managing PostgreSQL Testcontainers lifecycle.
+ * Starts single container for all tests extending this class.
+ */
+abstract class PgContainer {
+    companion object {
+        private val container = PostgreSQLContainer<Nothing>("postgres:16-alpine")
+        lateinit var dataSource: HikariDataSource
+        lateinit var database: Database
+
+        @JvmStatic
+        @BeforeAll
+        fun startContainer() {
+            assumeTrue(DockerClientFactory.instance().isDockerAvailable)
+            container.start()
+            val config = HikariConfig().apply {
+                jdbcUrl = container.jdbcUrl
+                username = container.username
+                password = container.password
+                driverClassName = container.driverClassName
+            }
+            dataSource = HikariDataSource(config)
+            database = Database.connect(dataSource)
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopContainer() {
+            if (this::dataSource.isInitialized) {
+                dataSource.close()
+            }
+            container.stop()
+        }
+    }
+}

--- a/core-testing/src/test/resources/application-test.conf
+++ b/core-testing/src/test/resources/application-test.conf
@@ -1,0 +1,14 @@
+ktor {
+  deployment {
+    port = 8080
+  }
+  application {
+    modules = [ com.example.bot.ApplicationKt.module ]
+  }
+}
+
+notify {
+  globalRps = 10
+  chatRps = 5.0
+  workerParallelism = 1
+}


### PR DESCRIPTION
## Summary
- add reusable test utilities for PostgreSQL containers, coroutines, metrics and logging
- cover availability, payment, outbox worker and route smoke scenarios with JUnit 5 tests
- document project testing instructions

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bff99812c48321a0aadff4156fccb0