### PR TITLE
Add docker-compose setup for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,29 @@
-BOT_TOKEN=
-WEBHOOK_SECRET_TOKEN=
-DATABASE_URL=
-DATABASE_USER=
-DATABASE_PASSWORD=
-OWNER_TELEGRAM_ID=
+# ------------------------------
+# Telegram bot (secrets → не коммитить реальные значения)
+# ------------------------------
+TELEGRAM_BOT_TOKEN=123456:REPLACE_ME
+OWNER_TELEGRAM_ID=7446417641
 
-# HQ
+# Webhook (optional)
+WEBHOOK_BASE_URL=
+WEBHOOK_SECRET_TOKEN=
+
+# ------------------------------
+# Local Bot API Server (optional)
+# ------------------------------
+# TELEGRAM_API_ID=
+# TELEGRAM_API_HASH=
+
+# ------------------------------
+# Workers / RatePolicy
+# ------------------------------
+GLOBAL_RPS=25
+CHAT_RPS=2
+WORKER_PARALLELISM=4
+
+# ------------------------------
+# HQ (global admin chat with topics)
+# ------------------------------
 HQ_CHAT_ID=-1002693051031
 HQ_GENERAL_THREAD_ID=19
 HQ_BOOKINGS_THREAD_ID=2
@@ -13,7 +31,9 @@ HQ_QA_THREAD_ID=6
 HQ_LISTS_THREAD_ID=3
 HQ_SYSTEM_THREAD_ID=4
 
+# ------------------------------
 # CLUB 1 (Mix)
+# ------------------------------
 CLUB1_CHAT_ID=-1003032666045
 CLUB1_GENERAL_THREAD_ID=1
 CLUB1_BOOKINGS_THREAD_ID=2
@@ -22,7 +42,9 @@ CLUB1_QA_THREAD_ID=4
 CLUB1_MEDIA_THREAD_ID=5
 CLUB1_SYSTEM_THREAD_ID=7
 
+# ------------------------------
 # CLUB 2 (Osobnyak)
+# ------------------------------
 CLUB2_CHAT_ID=-1003015873542
 CLUB2_GENERAL_THREAD_ID=1
 CLUB2_BOOKINGS_THREAD_ID=2
@@ -31,7 +53,9 @@ CLUB2_QA_THREAD_ID=5
 CLUB2_MEDIA_THREAD_ID=6
 CLUB2_SYSTEM_THREAD_ID=7
 
-# CLUB 3 (internal)
+# ------------------------------
+# CLUB 3 (internal name)
+# ------------------------------
 CLUB3_CHAT_ID=-1003082862964
 CLUB3_GENERAL_THREAD_ID=1
 CLUB3_BOOKINGS_THREAD_ID=2
@@ -40,7 +64,9 @@ CLUB3_QA_THREAD_ID=4
 CLUB3_MEDIA_THREAD_ID=5
 CLUB3_SYSTEM_THREAD_ID=6
 
+# ------------------------------
 # CLUB 4 (NN)
+# ------------------------------
 CLUB4_CHAT_ID=-1002988144234
 CLUB4_GENERAL_THREAD_ID=1
 CLUB4_BOOKINGS_THREAD_ID=2
@@ -48,6 +74,3 @@ CLUB4_LISTS_THREAD_ID=3
 CLUB4_QA_THREAD_ID=4
 CLUB4_MEDIA_THREAD_ID=5
 CLUB4_SYSTEM_THREAD_ID=6
-
-# Owner
-OWNER_TELEGRAM_ID=7446417641

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+SHELL := /bin/bash
+
+.PHONY: up down rebuild logs ps tail health psql
+
+up:
+@docker compose up -d --build
+
+down:
+@docker compose down -v
+
+rebuild:
+@docker compose build --no-cache app
+
+logs:
+@docker compose logs -f --tail=200 app
+
+ps:
+@docker compose ps
+
+tail:
+@docker compose logs -f app postgres
+
+health:
+@code=$$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health); \
+if [ "$$code" = "200" ]; then echo "OK"; else echo "FAIL ($$code)"; exit 1; fi
+
+psql:
+@docker exec -it bot_postgres psql -U botuser -d botdb

--- a/README.md
+++ b/README.md
@@ -78,3 +78,34 @@ Enable verbose logging:
 
 Test reports are generated under `build/reports/tests/test/index.html`.
 
+
+## Local run (Docker)
+
+1. Скопируй `.env.example` → `.env` и заполни **секреты** (минимум `TELEGRAM_BOT_TOKEN`).
+2. Подними всё:
+   ```bash
+   make up
+   ```
+3. Проверка:
+   ```bash
+   make health          # OK
+   curl -f http://localhost:8080/ready
+   ```
+4. Логи:
+   ```bash
+   make logs
+   ```
+5. Масштабирование (dev):
+   ```bash
+   docker compose up -d --scale app=2
+   docker compose ps
+   ```
+6. Подключиться к Postgres:
+   ```bash
+   make psql
+   ```
+
+Local Bot API Server (optional):  
+Разкомментируй сервис `telegram-bot-api` в `docker-compose.yml`, добавь в `.env` `TELEGRAM_API_ID`/`TELEGRAM_API_HASH`, и запусти `make up`.
+
+---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: bot_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: botdb
+      POSTGRES_USER: botuser
+      POSTGRES_PASSWORD: botpass
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U botuser -d botdb"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    networks: [bot_net]
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: bot_app
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    environment:
+      # --- Database ---
+      DATABASE_URL: jdbc:postgresql://postgres:5432/botdb
+      DATABASE_USER: botuser
+      DATABASE_PASSWORD: botpass
+
+      # --- Telegram bot (секреты задать в .env локально/в CI) ---
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:?set_in_.env}
+      OWNER_TELEGRAM_ID: ${OWNER_TELEGRAM_ID:-0}
+
+      # --- Webhook (optional) ---
+      WEBHOOK_BASE_URL: ${WEBHOOK_BASE_URL:-}
+      WEBHOOK_SECRET_TOKEN: ${WEBHOOK_SECRET_TOKEN:-}
+
+      # --- Workers / RatePolicy ---
+      GLOBAL_RPS: ${GLOBAL_RPS:-25}
+      CHAT_RPS: ${CHAT_RPS:-2}
+      WORKER_PARALLELISM: ${WORKER_PARALLELISM:-4}
+
+      # --- Ktor/Netty ---
+      PORT: 8080
+    ports:
+      - "8080:8080"
+    networks: [bot_net]
+
+  # Local Bot API Server (optional for high throughput)
+  # telegram-bot-api:
+  #   image: aiogram/telegram-bot-api:latest
+  #   container_name: local_bot_api
+  #   restart: unless-stopped
+  #   environment:
+  #     TELEGRAM_API_ID: ${TELEGRAM_API_ID:?set_in_.env}
+  #     TELEGRAM_API_HASH: ${TELEGRAM_API_HASH:?set_in_.env}
+  #     TELEGRAM_LOCAL: "true"
+  #   ports:
+  #     - "8081:8081"
+  #   networks: [bot_net]
+
+networks:
+  bot_net:
+
+volumes:
+  pg_data:


### PR DESCRIPTION
## Summary
- add docker-compose with Postgres and Ktor app
- provide sample `.env.example` with bot and chat variables
- add Makefile and README instructions for local Docker workflows

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d3af54088321828477fe754ba7fe