### PR TITLE
Add container smoke test script and CI workflow

### DIFF
--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -1,0 +1,94 @@
+name: Container Smoke
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        ports: [ "5432:5432" ]
+        env:
+          POSTGRES_DB: botdb
+          POSTGRES_USER: botuser
+          POSTGRES_PASSWORD: botpass
+        options: >-
+          --health-cmd "pg_isready -U botuser -d botdb"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21 (for potential Gradle pre-steps)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Build app image
+        run: docker build -t app-bot:ci .
+
+      - name: Wait for Postgres (port check)
+        run: |
+          for i in {1..60}; do
+            nc -z 127.0.0.1 5432 && echo "postgres OK" && exit 0
+            sleep 1
+          done
+          echo "postgres not ready" && exit 1
+
+      - name: Run app container
+        run: |
+          docker run -d --name app-bot-ci \
+            -p 8080:8080 \
+            -e DATABASE_URL="jdbc:postgresql://127.0.0.1:5432/botdb" \
+            -e DATABASE_USER="botuser" \
+            -e DATABASE_PASSWORD="botpass" \
+            -e TELEGRAM_BOT_TOKEN="000000:TEST" \
+            -e OWNER_TELEGRAM_ID="0" \
+            app-bot:ci
+
+      - name: Probe /health
+        run: |
+          for i in {1..60}; do
+            if curl -fsS http://127.0.0.1:8080/health >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "health failed" && exit 1
+
+      - name: Probe /ready
+        run: |
+          for i in {1..60}; do
+            if curl -fsS http://127.0.0.1:8080/ready >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ready failed" && exit 1
+
+      - name: Dump app logs on failure
+        if: failure()
+        run: docker logs app-bot-ci || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f app-bot-ci || true

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,32 @@
 SHELL := /bin/bash
 
-.PHONY: up down rebuild logs ps tail health psql
+.PHONY: up down rebuild logs ps tail health psql smoke
 
 up:
-@docker compose up -d --build
+	@docker compose up -d --build
 
 down:
-@docker compose down -v
+	@docker compose down -v
 
 rebuild:
-@docker compose build --no-cache app
+	@docker compose build --no-cache app
 
 logs:
-@docker compose logs -f --tail=200 app
+	@docker compose logs -f --tail=200 app
 
 ps:
-@docker compose ps
+	@docker compose ps
 
 tail:
-@docker compose logs -f app postgres
+	@docker compose logs -f app postgres
 
 health:
-@code=$$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health); \
+	@code=$$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health); \
 if [ "$$code" = "200" ]; then echo "OK"; else echo "FAIL ($$code)"; exit 1; fi
 
 psql:
-@docker exec -it bot_postgres psql -U botuser -d botdb
+	@docker exec -it bot_postgres psql -U botuser -d botdb
+
+smoke:
+	@chmod +x scripts/smoke.sh
+	@APP_IMAGE=app-bot:smoke APP_PORT=8080 ./scripts/smoke.sh

--- a/README.md
+++ b/README.md
@@ -109,3 +109,15 @@ Local Bot API Server (optional):
 Разкомментируй сервис `telegram-bot-api` в `docker-compose.yml`, добавь в `.env` `TELEGRAM_API_ID`/`TELEGRAM_API_HASH`, и запусти `make up`.
 
 ---
+
+## Container Smoke Test
+
+### Local
+```bash
+make smoke
+# под капотом: docker build, запуск postgres и app, ретраи /health и /ready до 60 сек
+```
+
+CI (GitHub Actions)
+- Workflow Container Smoke автоматически собирает образ, поднимает Postgres как сервис, стартует контейнер приложения и проверяет /health и /ready с ретраями.
+- Логи приложения выгружаются в шаге Dump app logs on failure при неуспехе.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_IMAGE="${APP_IMAGE:-app-bot:smoke}"
+APP_NAME="${APP_NAME:-bot_app_smoke}"
+PG_NAME="${PG_NAME:-bot_pg_smoke}"
+PG_PORT="${PG_PORT:-5432}"
+APP_PORT="${APP_PORT:-8080}"
+
+# Тестовые ENV (фиктивные значения)
+DB_URL="jdbc:postgresql://127.0.0.1:${PG_PORT}/botdb"
+DB_USER="botuser"
+DB_PASS="botpass"
+TELEGRAM_TOKEN="000000:TEST_TOKEN"
+OWNER_ID="0"
+
+cleanup() {
+  echo ">>> Cleanup"
+  docker rm -f "${APP_NAME}" >/dev/null 2>&1 || true
+  docker rm -f "${PG_NAME}"  >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo ">>> Build app image: ${APP_IMAGE}"
+docker build -t "${APP_IMAGE}" .
+
+echo ">>> Run Postgres: ${PG_NAME}"
+docker rm -f "${PG_NAME}" >/dev/null 2>&1 || true
+docker run -d --name "${PG_NAME}" \
+  -e POSTGRES_DB=botdb \
+  -e POSTGRES_USER="${DB_USER}" \
+  -e POSTGRES_PASSWORD="${DB_PASS}" \
+  -p "${PG_PORT}:5432" \
+  --health-cmd="pg_isready -U ${DB_USER} -d botdb" \
+  --health-interval=5s --health-timeout=3s --health-retries=10 \
+  postgres:16-alpine
+
+# Ждём Postgres (до 60 сек)
+echo ">>> Waiting for Postgres to be healthy..."
+for i in {1..60}; do
+  status="$(docker inspect -f '{{.State.Health.Status}}' "${PG_NAME}" || echo "unknown")"
+  if [[ "${status}" == "healthy" ]]; then
+    echo ">>> Postgres is healthy"
+    break
+  fi
+  sleep 1
+  if [[ $i -eq 60 ]]; then
+    echo "!!! Postgres did not become healthy in time"
+    docker logs "${PG_NAME}" || true
+    exit 1
+  fi
+
+done
+
+echo ">>> Run app: ${APP_NAME}"
+docker rm -f "${APP_NAME}" >/dev/null 2>&1 || true
+docker run -d --name "${APP_NAME}" \
+  -p "${APP_PORT}:8080" \
+  -e DATABASE_URL="${DB_URL}" \
+  -e DATABASE_USER="${DB_USER}" \
+  -e DATABASE_PASSWORD="${DB_PASS}" \
+  -e TELEGRAM_BOT_TOKEN="${TELEGRAM_TOKEN}" \
+  -e OWNER_TELEGRAM_ID="${OWNER_ID}" \
+  "${APP_IMAGE}"
+
+# Ретраи /health и /ready (до 60 сек)
+echo ">>> Probing /health and /ready"
+for i in {1..60}; do
+  if curl -fsS "http://127.0.0.1:${APP_PORT}/health" >/dev/null 2>&1; then
+    if curl -fsS "http://127.0.0.1:${APP_PORT}/ready"  >/dev/null 2>&1; then
+      echo ">>> Smoke OK"
+      exit 0
+    fi
+  fi
+  sleep 1
+
+done
+
+echo "!!! Smoke test FAILED — dumping logs"
+echo "----- app logs -----"
+docker logs "${APP_NAME}" || true
+echo "----- postgres logs -----"
+docker logs "${PG_NAME}" || true
+exit 1


### PR DESCRIPTION
## Summary
- add smoke test script to build image, launch postgres, and probe /health and /ready
- wire up `make smoke` target and README docs
- run container smoke test in CI via GitHub Actions

## Testing
- `make smoke` *(fails: docker: command not found)*
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b7cd75ec8321ade90aa8200ec70b