### PR TITLE
Align notify endpoints schema with migration and repository

### DIFF
--- a/app-bot/build.gradle.kts
+++ b/app-bot/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.JavaExec
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -55,4 +56,11 @@ dependencies {
 
 application {
     mainClass.set("com.example.bot.ApplicationKt")
+}
+
+tasks.register<JavaExec>("runMigrations") {
+    group = "application"
+    description = "Run Flyway migrations using app runtime"
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("com.example.bot.tools.MigrateMainKt")
 }

--- a/app-bot/src/main/kotlin/com/example/bot/tools/MigrateMain.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/tools/MigrateMain.kt
@@ -1,0 +1,21 @@
+package com.example.bot.tools
+
+import com.example.bot.data.db.DbConfig
+import com.example.bot.data.db.FlywayConfig
+import com.example.bot.data.db.HikariFactory
+import com.example.bot.data.db.MigrationRunner
+
+fun main() {
+    val db = DbConfig.fromEnv()
+    val fw = FlywayConfig.fromEnv()
+    val ds = HikariFactory.dataSource(db)
+    try {
+        val res = MigrationRunner(ds, fw).run()
+        println("Flyway OK: $res")
+    } finally {
+        try {
+            (ds as? AutoCloseable)?.close()
+        } catch (_: Throwable) {
+        }
+    }
+}

--- a/core-data/src/main/kotlin/com/example/bot/data/repo/NotifyEndpointRepository.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/repo/NotifyEndpointRepository.kt
@@ -10,16 +10,15 @@ import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransacti
 
 data class HqEndpoints(
     val chatId: Long,
-    val generalTopicId: Int?,
-    val bookingsTopicId: Int?,
-    val listsTopicId: Int?,
-    val qaTopicId: Int?,
-    val systemTopicId: Int?,
+    val general: Int?,
+    val bookings: Int?,
+    val lists: Int?,
+    val qa: Int?,
+    val system: Int?,
 )
 
 data class ClubNotify(
-    val id: Int,
-    val name: String,
+    val clubId: Int,
     val adminChatId: Long?,
     val generalTopicId: Int?,
     val bookingsTopicId: Int?,
@@ -51,18 +50,17 @@ class NotifyEndpointRepository(private val db: Database) {
     private fun ResultRow.toHqEndpoints(): HqEndpoints {
         return HqEndpoints(
             chatId = this[HqNotify.chatId],
-            generalTopicId = this[HqNotify.generalTopicId],
-            bookingsTopicId = this[HqNotify.bookingsTopicId],
-            listsTopicId = this[HqNotify.listsTopicId],
-            qaTopicId = this[HqNotify.qaTopicId],
-            systemTopicId = this[HqNotify.systemTopicId],
+            general = this[HqNotify.generalTopicId],
+            bookings = this[HqNotify.bookingsTopicId],
+            lists = this[HqNotify.listsTopicId],
+            qa = this[HqNotify.qaTopicId],
+            system = this[HqNotify.systemTopicId],
         )
     }
 
     private fun ResultRow.toClubNotify(): ClubNotify {
         return ClubNotify(
-            id = this[Clubs.id].value,
-            name = this[Clubs.name],
+            clubId = this[Clubs.id].value,
             adminChatId = this[Clubs.adminChatId],
             generalTopicId = this[Clubs.generalTopicId],
             bookingsTopicId = this[Clubs.bookingsTopicId],

--- a/core-data/src/main/resources/db/migration/V6__telegram_notify_endpoints.sql
+++ b/core-data/src/main/resources/db/migration/V6__telegram_notify_endpoints.sql
@@ -29,15 +29,11 @@ CREATE TABLE IF NOT EXISTS hq_notify (
     system_topic_id INT NULL
 );
 
+COMMENT ON TABLE hq_notify IS 'Telegram notify endpoints for HQ admin chat';
+
+DELETE FROM hq_notify WHERE id = 1;
 INSERT INTO hq_notify (id, chat_id, general_topic_id, bookings_topic_id, lists_topic_id, qa_topic_id, system_topic_id)
-VALUES (1, -1002693051031, 19, 2, 3, 6, 4)
-ON CONFLICT (id) DO UPDATE SET
-    chat_id = EXCLUDED.chat_id,
-    general_topic_id = EXCLUDED.general_topic_id,
-    bookings_topic_id = EXCLUDED.bookings_topic_id,
-    lists_topic_id = EXCLUDED.lists_topic_id,
-    qa_topic_id = EXCLUDED.qa_topic_id,
-    system_topic_id = EXCLUDED.system_topic_id;
+VALUES (1, -1002693051031, 19, 2, 3, 6, 4);
 
 -- Ensure club records exist
 INSERT INTO clubs (name, timezone)


### PR DESCRIPTION
## Summary
- refine migration seeding and comment for HQ notify endpoints
- streamline NotifyEndpointRepository DTOs for HQ and clubs
- add runtime Flyway migration runner and Gradle task

## Testing
- `./gradlew build`
- `DATABASE_URL=jdbc:postgresql://localhost:5432/botdb DATABASE_USER=botuser DATABASE_PASSWORD=botpass ./gradlew :app-bot:runMigrations --console=plain` *(fails: Connection to localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c60b9cbe448321b94ab0dda9bf7343