### PR TITLE
feat: add hikari and tx retry tuning

### DIFF
--- a/core-data/src/main/kotlin/com/example/bot/data/db/DbMetrics.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/db/DbMetrics.kt
@@ -1,0 +1,15 @@
+package com.example.bot.data.db
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Простейшие счётчики. При желании их можно связать с Micrometer.
+ */
+object DbMetrics {
+    val txRetries: AtomicLong = AtomicLong(0)
+    val slowQueryCount: AtomicLong = AtomicLong(0)
+
+    // Пример интегратора с Micrometer (по желанию):
+    // fun maybeBindMicrometer(registry: io.micrometer.core.instrument.MeterRegistry) { ... }
+}
+

--- a/core-data/src/main/kotlin/com/example/bot/data/db/HikariFactory.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/db/HikariFactory.kt
@@ -5,22 +5,30 @@ import com.zaxxer.hikari.HikariDataSource
 import javax.sql.DataSource
 
 object HikariFactory {
-    fun dataSource(db: DbConfig): DataSource {
-        val hc =
-            HikariConfig().apply {
-                jdbcUrl = db.url
-                username = db.user
-                password = db.password
 
-                maximumPoolSize = DEFAULT_MAX_POOL_SIZE
-                minimumIdle = DEFAULT_MIN_IDLE
-                isAutoCommit = false
-                transactionIsolation = "TRANSACTION_REPEATABLE_READ"
-                validate()
-            }
+    private fun envInt(name: String, default: Int): Int =
+        System.getenv(name)?.toIntOrNull() ?: default
+
+    private fun envLong(name: String, default: Long): Long =
+        System.getenv(name)?.toLongOrNull() ?: default
+
+    fun dataSource(db: DbConfig): DataSource {
+        val hc = HikariConfig().apply {
+            jdbcUrl = db.url
+            username = db.user
+            password = db.password
+
+            maximumPoolSize = envInt("HIKARI_MAX_POOL_SIZE", 20)
+            minimumIdle = envInt("HIKARI_MIN_IDLE", 2)
+            connectionTimeout = envLong("HIKARI_CONN_TIMEOUT_MS", 5_000)
+            validationTimeout = envLong("HIKARI_VALIDATION_TIMEOUT_MS", 2_000)
+            leakDetectionThreshold = envLong("HIKARI_LEAK_DETECTION_MS", 10_000)
+
+            isAutoCommit = false
+            transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+            validate()
+        }
         return HikariDataSource(hc)
     }
 }
 
-private const val DEFAULT_MAX_POOL_SIZE = 20
-private const val DEFAULT_MIN_IDLE = 2

--- a/core-data/src/main/kotlin/com/example/bot/data/db/Tx.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/db/Tx.kt
@@ -1,0 +1,112 @@
+package com.example.bot.data.db
+
+import java.sql.SQLException
+import java.util.concurrent.ThreadLocalRandom
+import kotlin.math.min
+import kotlin.system.measureNanoTime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.slf4j.LoggerFactory
+
+/**
+ * Настройки retry/backoff читаются из ENV; есть дефолты.
+ */
+private fun envInt(name: String, default: Int): Int =
+    System.getenv(name)?.toIntOrNull() ?: default
+
+private fun envLong(name: String, default: Long): Long =
+    System.getenv(name)?.toLongOrNull() ?: default
+
+private val log = LoggerFactory.getLogger("DB.Tx")
+
+private val MAX_RETRIES: Int = envInt("DB_TX_MAX_RETRIES", 3)
+private val BASE_BACKOFF_MS: Long = envLong("DB_TX_BASE_BACKOFF_MS", 500)
+private val MAX_BACKOFF_MS: Long = envLong("DB_TX_MAX_BACKOFF_MS", 15_000)
+private val JITTER_MS: Long = envLong("DB_TX_JITTER_MS", 100)
+private val SLOW_QUERY_MS: Long = envLong("DB_SLOW_QUERY_MS", 200)
+
+/**
+ * Возвращает SQLState из цепочки причин, если есть.
+ */
+private fun sqlStateOf(ex: Throwable): String? {
+    var cur: Throwable? = ex
+    while (cur != null) {
+        if (cur is SQLException) return cur.sqlState
+        cur = cur.cause
+    }
+    return null
+}
+
+private fun isRetryableSqlState(sqlState: String?): Boolean {
+    // PostgreSQL: 40P01 (deadlock detected), 40001 (serialization failure)
+    return sqlState == "40P01" || sqlState == "40001"
+}
+
+/**
+ * Экспоненциальный backoff с джиттером [0..JITTER_MS].
+ */
+private suspend fun backoff(attempt: Int) {
+    val exp = 1L shl attempt.coerceAtMost(20) // защита от переполнения
+    val base = BASE_BACKOFF_MS * exp
+    val delayMs = min(base, MAX_BACKOFF_MS)
+    val jitter = if (JITTER_MS > 0) ThreadLocalRandom.current().nextLong(0, JITTER_MS + 1) else 0
+    delay(delayMs + jitter)
+}
+
+/**
+ * Выполнить блок внутри Exposed-транзакции (IO), с retry на deadlock/serialization,
+ * и slow-query логом по порогу SLOW_QUERY_MS.
+ */
+suspend fun <T> txRetrying(db: Database? = null, block: suspend () -> T): T {
+    var attempt = 0
+    var lastError: Throwable? = null
+
+    while (attempt <= MAX_RETRIES) {
+        try {
+            var result: T
+            val elapsed = measureNanoTime {
+                result =
+                    newSuspendedTransaction(
+                        context = Dispatchers.IO,
+                        db = db,
+                    ) {
+                        block.invoke()
+                    }
+            }
+            val tookMs = elapsed / 1_000_000
+            if (tookMs > SLOW_QUERY_MS) {
+                DbMetrics.slowQueryCount.incrementAndGet()
+                log.warn("Slow transaction detected: {} ms > {} ms", tookMs, SLOW_QUERY_MS)
+            }
+            return result
+        } catch (ex: Throwable) {
+            lastError = ex
+            val state = sqlStateOf(ex)
+            val retryable = isRetryableSqlState(state)
+            if (!retryable || attempt == MAX_RETRIES) {
+                log.error(
+                    "DB tx failed (attempt={} / max={}, sqlState={}): {}",
+                    attempt,
+                    MAX_RETRIES,
+                    state,
+                    ex.toString(),
+                )
+                throw ex
+            }
+            DbMetrics.txRetries.incrementAndGet()
+            log.warn(
+                "DB tx retrying (attempt={} / max={}, sqlState={}): {}",
+                attempt + 1,
+                MAX_RETRIES,
+                state,
+                ex.toString(),
+            )
+            attempt += 1
+            backoff(attempt)
+        }
+    }
+    throw lastError ?: IllegalStateException("txRetrying failed without exception")
+}
+

--- a/core-data/src/main/kotlin/com/example/bot/data/repo/RetryExampleRepository.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/repo/RetryExampleRepository.kt
@@ -1,0 +1,16 @@
+package com.example.bot.data.repo
+
+import com.example.bot.data.db.txRetrying
+
+/**
+ * Пример применения txRetrying в репозитории.
+ * Здесь мы не привязываемся к конкретным таблицам, а демонстрируем шаблон.
+ */
+class RetryExampleRepository {
+
+    suspend fun doSomethingWithRetry(): Int = txRetrying {
+        // Здесь могла быть ваша Exposed-логика; ниже — заглушка для примера:
+        42
+    }
+}
+


### PR DESCRIPTION
## Summary
- make Hikari configurable via ENV and set safe defaults
- add DB metrics and transaction retry helper with backoff
- include example repository demonstrating txRetrying

## Testing
- `./gradlew :core-data:build`


------
https://chatgpt.com/codex/tasks/task_e_68c63a9ac0b4832199aee254e76693f0