### PR TITLE
Implement token-bucket rate limiting plugin

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/Application.kt
@@ -1,7 +1,7 @@
 package com.example.bot
 
 import com.example.bot.plugins.installAppConfig
-import com.example.bot.plugins.installHotPathLimiterDefaults
+import com.example.bot.plugins.installRateLimitPluginDefaults
 import com.example.bot.plugins.installMetrics
 import com.example.bot.plugins.installMigrationsAndDatabase
 import com.example.bot.plugins.installRequestLogging
@@ -17,8 +17,8 @@ import io.ktor.server.routing.routing
 fun Application.module() {
     // 0) Тюнинг сервера (лимиты размера запроса и пр.)
     installServerTuning()
-    // 1) Лимиты на «горячие» пути (429 при переполнении)
-    installHotPathLimiterDefaults()
+    // 1) Rate limiting: IP + per-subject (429 при переполнении)
+    installRateLimitPluginDefaults()
     // 2) Migrations + DB (18.3)
     installMigrationsAndDatabase()
     // 3) AppConfig (этот шаг должен идти раньше бизнес-логики)

--- a/app-bot/src/main/kotlin/com/example/bot/plugins/RateLimitPlugin.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/plugins/RateLimitPlugin.kt
@@ -1,0 +1,130 @@
+package com.example.bot.plugins
+
+import com.example.bot.ratelimit.SubjectBucketStore
+import com.example.bot.ratelimit.TokenBucket
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.request.header
+import io.ktor.server.request.host
+import io.ktor.server.request.path
+import io.ktor.server.request.port
+import io.ktor.server.response.header
+import io.ktor.server.response.respondText
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Конфиг для rate-limiting.
+ */
+class RateLimitConfig {
+    // IP
+    var ipEnabled: Boolean = (System.getenv("RL_IP_ENABLED")?.toBooleanStrictOrNull() ?: true)
+    var ipRps: Double = (System.getenv("RL_IP_RPS")?.toDoubleOrNull() ?: 100.0)
+    var ipBurst: Double = (System.getenv("RL_IP_BURST")?.toDoubleOrNull() ?: 20.0)
+
+    // Subject (например, chatId)
+    var subjectEnabled: Boolean = (System.getenv("RL_SUBJECT_ENABLED")?.toBooleanStrictOrNull() ?: true)
+    var subjectRps: Double = (System.getenv("RL_SUBJECT_RPS")?.toDoubleOrNull() ?: 60.0)
+    var subjectBurst: Double = (System.getenv("RL_SUBJECT_BURST")?.toDoubleOrNull() ?: 20.0)
+    var subjectTtlSeconds: Long = (System.getenv("RL_SUBJECT_TTL_SECONDS")?.toLongOrNull() ?: 600L)
+    var subjectPathPrefixes: List<String> = listOf(
+        "/webhook",
+        "/api/bookings/confirm",
+        "/api/guest-lists/import"
+    )
+
+    /**
+     * Извлекает ключ для subject-лимитера (например, chatId).
+     * По умолчанию пробуем X-Chat-Id, X-Telegram-Chat-Id, query chatId, иначе null.
+     */
+    var subjectKeyExtractor: suspend (io.ktor.server.application.ApplicationCall) -> String? = { call ->
+        call.request.header("X-Chat-Id")
+            ?: call.request.header("X-Telegram-Chat-Id")
+            ?: call.request.queryParameters["chatId"]
+    }
+
+    // Ответ при ограничении
+    var retryAfterSeconds: Int = (System.getenv("RL_RETRY_AFTER_SECONDS")?.toIntOrNull() ?: 1)
+}
+
+object RateLimitMetrics {
+    val ipBlocked = AtomicLong(0)
+    val subjectBlocked = AtomicLong(0)
+    val subjectStoreSize = AtomicLong(0)
+}
+
+private fun String?.toBooleanStrictOrNull(): Boolean? = when (this?.lowercase()) {
+    "true" -> true
+    "false" -> false
+    else -> null
+}
+
+val RateLimitPlugin = createApplicationPlugin(name = "RateLimitPlugin", createConfiguration = ::RateLimitConfig) {
+    val cfg = pluginConfig
+
+    val ipBuckets = ConcurrentHashMap<String, TokenBucket>()
+
+    val subjectStore = SubjectBucketStore(
+        capacity = cfg.subjectBurst,
+        refillPerSec = cfg.subjectRps,
+        ttl = Duration.ofSeconds(cfg.subjectTtlSeconds)
+    )
+
+    onCall { call ->
+        val path = call.request.path()
+
+        // 1) IP limiting
+        if (cfg.ipEnabled) {
+            val ip = clientIp(call)
+            val bucket = ipBuckets.computeIfAbsent(ip) {
+                TokenBucket(capacity = cfg.ipBurst, refillPerSec = cfg.ipRps)
+            }
+            if (!bucket.tryAcquire()) {
+                RateLimitMetrics.ipBlocked.incrementAndGet()
+                call.response.header(HttpHeaders.RetryAfter, cfg.retryAfterSeconds.toString())
+                call.respondText("Too Many Requests (IP limit)", status = HttpStatusCode.TooManyRequests)
+                return@onCall
+            }
+        }
+
+        // 2) Subject limiting
+        if (cfg.subjectEnabled && cfg.subjectPathPrefixes.any { path.startsWith(it) }) {
+            val key = cfg.subjectKeyExtractor(call)
+            if (key != null) {
+                val ok = subjectStore.tryAcquire(key)
+                RateLimitMetrics.subjectStoreSize.set(subjectStore.size())
+                if (!ok) {
+                    RateLimitMetrics.subjectBlocked.incrementAndGet()
+                    call.response.header(HttpHeaders.RetryAfter, cfg.retryAfterSeconds.toString())
+                    call.respondText("Too Many Requests (subject limit)", status = HttpStatusCode.TooManyRequests)
+                    return@onCall
+                }
+            }
+        }
+    }
+}
+
+private fun clientIp(call: io.ktor.server.application.ApplicationCall): String {
+    val xff = call.request.header("X-Forwarded-For")
+    if (!xff.isNullOrBlank()) {
+        val first = xff.split(',').first().trim()
+        if (first.isNotEmpty()) return first
+    }
+    val real = call.request.header("X-Real-IP")
+    if (!real.isNullOrBlank()) {
+        return real
+    }
+    return call.request.host() + ":" + call.request.port()
+}
+
+fun Application.installRateLimitPluginDefaults() {
+    install(RateLimitPlugin) {
+        // настройки уже берутся из ENV; путь и extractor можно переопределить при необходимости
+    }
+}
+

--- a/app-bot/src/main/kotlin/com/example/bot/ratelimit/TokenBucket.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/ratelimit/TokenBucket.kt
@@ -1,0 +1,96 @@
+package com.example.bot.ratelimit
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Простой потокобезопасный токен-бакет:
+ *  - capacity: максимум токенов (burst)
+ *  - refillPerSec: скорость пополнения в токенах/сек
+ */
+class TokenBucket(
+    capacity: Double,
+    refillPerSec: Double,
+    nowNanos: Long = System.nanoTime()
+) {
+    private val capacity = capacity.coerceAtLeast(1.0)
+    private val refillPerSec = refillPerSec.coerceAtLeast(0.1)
+    @Volatile private var tokens: Double = this.capacity
+    @Volatile private var lastRefillNs: Long = nowNanos
+
+    /**
+     * Пытается взять 1 токен.
+     * Возвращает true, если удалось (не блокирует), иначе false.
+     */
+    @Synchronized
+    fun tryAcquire(nowNanos: Long = System.nanoTime()): Boolean {
+        refill(nowNanos)
+        return if (tokens >= 1.0) {
+            tokens -= 1.0
+            true
+        } else {
+            false
+        }
+    }
+
+    @Synchronized
+    private fun refill(nowNanos: Long) {
+        val elapsedNs = max(0L, nowNanos - lastRefillNs)
+        if (elapsedNs <= 0) return
+        val elapsedSec = elapsedNs / 1_000_000_000.0
+        tokens = min(capacity, tokens + elapsedSec * refillPerSec)
+        lastRefillNs = nowNanos
+    }
+}
+
+/**
+ * Хранилище subject-бакетов с TTL (удаляем неиспользуемые).
+ */
+class SubjectBucketStore(
+    private val capacity: Double,
+    private val refillPerSec: Double,
+    private val ttl: Duration
+) {
+    private data class Entry(val bucket: TokenBucket, @Volatile var lastSeen: Instant)
+    private val map = ConcurrentHashMap<String, Entry>()
+    private val _size = AtomicLong(0)
+
+    fun tryAcquire(subjectKey: String): Boolean {
+        val now = Instant.now()
+        val entry = map.compute(subjectKey) { _, old ->
+            val e = if (old == null) {
+                Entry(TokenBucket(capacity, refillPerSec), now).also { _size.incrementAndGet() }
+            } else {
+                old.lastSeen = now
+                old
+            }
+            e
+        }!!
+        val ok = entry.bucket.tryAcquire()
+        if (!ok) {
+            cleanupIfNeeded(now)
+        }
+        return ok
+    }
+
+    fun size(): Long = _size.get()
+
+    private fun cleanupIfNeeded(now: Instant) {
+        // Ленивая очистка: если карта разрослась, удалим протухшие
+        if (map.size < 10_000) return
+        var removed = 0
+        for ((k, v) in map.entries) {
+            if (Duration.between(v.lastSeen, now).seconds >= ttl.seconds) {
+                if (map.remove(k, v)) removed++
+            }
+        }
+        if (removed > 0) {
+            _size.addAndGet(-removed.toLong())
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add thread-safe token bucket and subject bucket store
- create Ktor rate limit plugin with IP and subject limits, Retry-After header, and metrics
- enable rate limiting early in Application module

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c647afcfbc8321966ff754987f93e9