### PR TITLE
Implement one-time tokens for Telegram callbacks

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/Application.kt
@@ -1,15 +1,23 @@
 package com.example.bot
 
 import com.example.bot.plugins.installAppConfig
-import com.example.bot.plugins.installRateLimitPluginDefaults
 import com.example.bot.plugins.installMetrics
 import com.example.bot.plugins.installMigrationsAndDatabase
+import com.example.bot.plugins.installRateLimitPluginDefaults
 import com.example.bot.plugins.installRequestLogging
 import com.example.bot.render.DefaultHallRenderer
 import com.example.bot.routes.hallImageRoute
 import com.example.bot.routes.healthRoute
 import com.example.bot.routes.readinessRoute
 import com.example.bot.server.installServerTuning
+import com.example.bot.telegram.ott.BookTableAction
+import com.example.bot.telegram.ott.CallbackQueryHandler
+import com.example.bot.telegram.ott.CallbackTokenService
+import com.example.bot.telegram.ott.KeyboardFactory
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.UpdatesListener
+import com.pengrad.telegrambot.model.Update
+import com.pengrad.telegrambot.request.SendMessage
 import io.ktor.server.application.Application
 import io.ktor.server.routing.routing
 
@@ -34,4 +42,32 @@ fun Application.module() {
         hallImageRoute(renderer) { _, _ -> "v1" }
         // … остальные маршруты приложения
     }
+
+    // Telegram bot demo integration
+    val telegramToken = System.getenv("TELEGRAM_BOT_TOKEN") ?: "000000:DEV"
+    val bot = TelegramBot(telegramToken)
+    val ottService = CallbackTokenService()
+    val callbackHandler = CallbackQueryHandler(bot, ottService)
+    bot.setUpdatesListener(object : UpdatesListener {
+        override fun process(updates: MutableList<Update>?): Int {
+            if (updates == null) return UpdatesListener.CONFIRMED_UPDATES_ALL
+            for (u in updates) {
+                if (u.callbackQuery() != null) {
+                    callbackHandler.handle(u)
+                } else if (u.message() != null && u.message().text() == "/demo") {
+                    val chatId = u.message().chat().id()
+                    val kb = KeyboardFactory.tableKeyboard(
+                        service = ottService,
+                        items = listOf(
+                            "Стол 101" to BookTableAction(1L, "2025-12-31T22:00:00Z", 101L),
+                            "Стол 102" to BookTableAction(1L, "2025-12-31T22:00:00Z", 102L),
+                            "Стол 103" to BookTableAction(1L, "2025-12-31T22:00:00Z", 103L)
+                        )
+                    )
+                    bot.execute(SendMessage(chatId, "Выберите стол:").replyMarkup(kb))
+                }
+            }
+            return UpdatesListener.CONFIRMED_UPDATES_ALL
+        }
+    })
 }

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/ott/KeyboardFactory.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/ott/KeyboardFactory.kt
@@ -1,0 +1,25 @@
+package com.example.bot.telegram.ott
+
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+
+object KeyboardFactory {
+
+    /**
+     * Пример: клавиатура со столами, где в callback_data — одноразовый токен.
+     * @param items пары (label, payload)
+     */
+    fun tableKeyboard(
+        service: CallbackTokenService,
+        items: List<Pair<String, BookTableAction>>
+    ): InlineKeyboardMarkup {
+        val buttons = items.map { (label, payload) ->
+            val token = service.issueToken(payload)
+            InlineKeyboardButton(label).callbackData(token)
+        }
+        // Разложим по рядам по 2 кнопки
+        val rows = buttons.chunked(2).map { it.toTypedArray() }.toTypedArray()
+        return InlineKeyboardMarkup(*rows)
+    }
+}
+

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/ott/OneTimeTokenStore.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/ott/OneTimeTokenStore.kt
@@ -1,0 +1,124 @@
+package com.example.bot.telegram.ott
+
+import java.security.SecureRandom
+import java.time.Duration
+import java.time.Instant
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.min
+
+/** Маркер всех payload’ов, на которые мапится одноразовый токен. */
+sealed interface OttPayload
+
+/** Пример payload’а: действие «забронировать стол». */
+data class BookTableAction(
+    val clubId: Long,
+    val startUtc: String,
+    val tableId: Long
+) : OttPayload
+
+/** Простейшие метрики стора. */
+object OttMetrics {
+    val issued = AtomicLong(0)
+    val consumed = AtomicLong(0)
+    val replayed = AtomicLong(0)
+    val storeSize = AtomicInteger(0)
+}
+
+/** API стора: issue — выдать новый токен; consume — атомарно получить payload и удалить. */
+interface OneTimeTokenStore {
+    fun issue(payload: OttPayload): String
+    fun consume(token: String): OttPayload?
+    fun size(): Int
+}
+
+/**
+ * In-memory One-Time Token Store:
+ *  - TTL: истёкшие записи очищаются лениво;
+ *  - LRU-ограничение по размеру: при переполнении — эвиктим в порядке вставки (упрощённо);
+ *  - Потокобезопасность: ConcurrentHashMap + lock-free очереди.
+ */
+class InMemoryOneTimeTokenStore(
+    ttlSeconds: Long = System.getenv("OTT_TTL_SECONDS")?.toLongOrNull() ?: 300L,
+    maxEntries: Int = System.getenv("OTT_MAX_ENTRIES")?.toIntOrNull() ?: 100_000
+) : OneTimeTokenStore {
+
+    private data class Entry(val payload: OttPayload, val expiresAt: Instant)
+
+    private val ttl: Duration = Duration.ofSeconds(ttlSeconds.coerceAtLeast(30))
+    private val maxEntries: Int = maxEntries.coerceAtLeast(1)
+
+    private val map = ConcurrentHashMap<String, Entry>(16, 0.75f, 4)
+    private val order = ConcurrentLinkedQueue<String>() // упрощённое LRU по порядку вставки
+
+    // CSPRNG для токенов
+    private val random = SecureRandom()
+
+    override fun issue(payload: OttPayload): String {
+        cleanupIfNeeded()
+        val token = generateToken()
+        val entry = Entry(payload = payload, expiresAt = Instant.now().plus(ttl))
+        map[token] = entry
+        order.add(token)
+        OttMetrics.issued.incrementAndGet()
+        OttMetrics.storeSize.set(map.size)
+        return token
+    }
+
+    override fun consume(token: String): OttPayload? {
+        cleanupIfNeeded()
+        val entry = map.remove(token) ?: run {
+            OttMetrics.replayed.incrementAndGet()
+            return null
+        }
+        OttMetrics.storeSize.set(map.size)
+        return if (Instant.now().isAfter(entry.expiresAt)) {
+            // истёк — считаем как replay/просрочку
+            OttMetrics.replayed.incrementAndGet()
+            null
+        } else {
+            OttMetrics.consumed.incrementAndGet()
+            entry.payload
+        }
+    }
+
+    override fun size(): Int = map.size
+
+    private fun generateToken(): String {
+        // 16–24 байта энтропии → base64url без паддинга; длина < 64
+        val len = 20 + random.nextInt(5) // 20..24
+        val bytes = ByteArray(len)
+        random.nextBytes(bytes)
+        val b64 = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+        // страховка на редкий случай длинее 64 (не случится при выбранных размерах)
+        return if (b64.length <= 64) b64 else b64.substring(0, 64)
+    }
+
+    private fun cleanupIfNeeded() {
+        // Простая эвикция по переполнению
+        while (map.size > maxEntries) {
+            val victim = order.poll() ?: break
+            map.remove(victim)
+        }
+        // Ленивая TTL-очистка при большом размере
+        if (map.size > min(10_000, maxEntries / 2)) {
+            val now = Instant.now()
+            var removed = 0
+            for (k in order) {
+                val e = map[k] ?: continue
+                if (now.isAfter(e.expiresAt)) {
+                    if (map.remove(k, e)) {
+                        removed++
+                    }
+                }
+            }
+            if (removed > 0) {
+                OttMetrics.storeSize.set(map.size)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add in-memory one-time token store with TTL, LRU eviction, and metrics
- provide service and handler to consume callback token payloads
- integrate keyboard helper and demo Telegram bot setup

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c64a4209b08321b854ee8b07d5d5b9