### PR TITLE
Expose env tuning and Micrometer metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,49 @@ CLUB4_LISTS_THREAD_ID=3
 CLUB4_QA_THREAD_ID=4
 CLUB4_MEDIA_THREAD_ID=5
 CLUB4_SYSTEM_THREAD_ID=6
+# ------------------------------
+# Rate Limit (20.5)
+# ------------------------------
+RL_IP_ENABLED=true
+RL_IP_RPS=100
+RL_IP_BURST=20
+RL_SUBJECT_ENABLED=true
+RL_SUBJECT_RPS=60
+RL_SUBJECT_BURST=20
+RL_SUBJECT_TTL_SECONDS=600
+RL_RETRY_AFTER_SECONDS=1
+
+# ------------------------------
+# Hot Path limiter (20.1)
+# ------------------------------
+HOT_PATH_MAX_CONCURRENT=8
+HOT_PATH_RETRY_AFTER_SEC=1
+MAX_REQUEST_SIZE_BYTES=2097152
+
+# ------------------------------
+# One-Time Tokens (20.6)
+# ------------------------------
+OTT_TTL_SECONDS=300
+OTT_MAX_ENTRIES=100000
+
+# ------------------------------
+# Hall render cache (20.4)
+# ------------------------------
+HALL_CACHE_MAX_ENTRIES=500
+HALL_CACHE_TTL_SECONDS=60
+HALL_BASE_IMAGE_VERSION=1
+
+# ------------------------------
+# Hikari / Tx tuning (20.2)
+# ------------------------------
+HIKARI_MAX_POOL_SIZE=20
+HIKARI_MIN_IDLE=2
+HIKARI_CONN_TIMEOUT_MS=5000
+HIKARI_VALIDATION_TIMEOUT_MS=2000
+HIKARI_LEAK_DETECTION_MS=10000
+
+DB_TX_MAX_RETRIES=3
+DB_TX_BASE_BACKOFF_MS=500
+DB_TX_MAX_BACKOFF_MS=15000
+DB_TX_JITTER_MS=100
+DB_SLOW_QUERY_MS=200

--- a/app-bot/src/main/kotlin/com/example/bot/metrics/AppMetricsBinder.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/metrics/AppMetricsBinder.kt
@@ -1,0 +1,39 @@
+package com.example.bot.metrics
+
+import com.example.bot.cache.HallCacheMetrics
+import com.example.bot.data.db.DbMetrics
+import com.example.bot.plugins.RateLimitMetrics
+import com.example.bot.telegram.NotifyMetrics
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Разовая привязка простых Atomic-метрик к Micrometer registry.
+ * Вызывать один раз после установки MicrometerMetrics.
+ */
+object AppMetricsBinder {
+
+    fun bindAll(registry: MeterRegistry) {
+        // Hall cache (20.4)
+        registry.gauge("hall.cache.evictions", HallCacheMetrics.evictions)
+        registry.gauge("hall.cache.renders.ms.sum", HallCacheMetrics.rendersMs)
+        // хит/миссы лучше как counters — сделаем прокси-гейдж: чтобы не ломать текущую реализацию
+        registry.gauge("hall.cache.hits", AtomicLong(HallCacheMetrics.hits.sum()))
+        registry.gauge("hall.cache.misses", AtomicLong(HallCacheMetrics.misses.sum()))
+
+        // Rate limit (20.5)
+        registry.gauge("ratelimit.ip.blocked", RateLimitMetrics.ipBlocked)
+        registry.gauge("ratelimit.subject.blocked", RateLimitMetrics.subjectBlocked)
+        registry.gauge("ratelimit.subject.size", RateLimitMetrics.subjectStoreSize)
+
+        // Telegram sender (20.3)
+        registry.gauge("tg.send.ok.atomic", NotifyMetrics.ok)
+        registry.gauge("tg.send.retry_after.atomic", NotifyMetrics.retryAfter)
+        registry.gauge("tg.send.retryable.atomic", NotifyMetrics.retryable)
+        registry.gauge("tg.send.permanent.atomic", NotifyMetrics.permanent)
+
+        // DB metrics (20.2)
+        registry.gauge("db.tx.retries.atomic", DbMetrics.txRetries)
+        registry.gauge("db.query.slow.count.atomic", DbMetrics.slowQueryCount)
+    }
+}

--- a/app-bot/src/main/kotlin/com/example/bot/plugins/MetricsPlugin.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/plugins/MetricsPlugin.kt
@@ -8,12 +8,15 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
 
 private val prometheusRegistry: PrometheusMeterRegistry by lazy {
     PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 }
+
+fun meterRegistry(): MeterRegistry = prometheusRegistry
 
 fun Application.installMetrics() {
     install(MicrometerMetrics) {

--- a/app-bot/src/main/kotlin/com/example/bot/render/HallRenderer.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/render/HallRenderer.kt
@@ -1,5 +1,7 @@
 package com.example.bot.render
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.awt.BasicStroke
 import java.awt.Color
 import java.awt.Font
@@ -7,20 +9,13 @@ import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 interface HallRenderer {
     /**
      * Вернуть PNG-байты схемы зала.
      * scale — множитель для Retina/увеличенного качества (например, 2.0).
      */
-    suspend fun render(
-        clubId: Long,
-        startUtc: String,
-        scale: Double,
-        stateKey: String
-    ): ByteArray
+    suspend fun render(clubId: Long, startUtc: String, scale: Double, stateKey: String): ByteArray
 }
 
 /**
@@ -28,86 +23,114 @@ interface HallRenderer {
  * Рисует сетку, рамку, минимальные подписи.
  */
 class DefaultHallRenderer : HallRenderer {
-
-    override suspend fun render(
-        clubId: Long,
-        startUtc: String,
-        scale: Double,
-        stateKey: String
-    ): ByteArray = withContext(Dispatchers.Default) {
-        val baseW = 800
-        val baseH = 500
-        val s = if (scale.isFinite() && scale > 0.1) scale else 1.0
-        val w = (baseW * s).toInt()
-        val h = (baseH * s).toInt()
-
-        val img = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
-        val g = img.createGraphics()
-        try {
-            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
-            // фон
-            g.color = Color(15, 17, 21)
-            g.fillRect(0, 0, w, h)
-
-            // сетка
-            g.color = Color(32, 38, 50)
-            val step = (40 * s).toInt().coerceAtLeast(20)
-            var x = 0
-            while (x < w) {
-                g.drawLine(x, 0, x, h)
-                x += step
-            }
-            var y = 0
-            while (y < h) {
-                g.drawLine(0, y, w, y)
-                y += step
-            }
-
-            // рамка зала
-            g.color = Color(96, 165, 250)
-            g.stroke = BasicStroke((3f * s).toFloat())
-            g.drawRect((20 * s).toInt(), (20 * s).toInt(), (w - 40 * s).toInt(), (h - 40 * s).toInt())
-
-            // подписи
-            g.font = Font("SansSerif", Font.BOLD, (18 * s).toInt())
-            g.color = Color(203, 213, 225)
-            g.drawString("Club #$clubId  •  Night: $startUtc", (30 * s).toInt(), (40 * s).toInt())
-            g.font = Font("SansSerif", Font.PLAIN, (14 * s).toInt())
-            g.drawString("state: $stateKey", (30 * s).toInt(), (60 * s).toInt())
-            val ver = System.getenv("HALL_BASE_IMAGE_VERSION") ?: "1"
-            g.drawString("v$ver  •  scale=${"%.1f".format(s)}", (30 * s).toInt(), (80 * s).toInt())
-
-            // легенда
-            val legendY = h - (60 * s).toInt()
-            drawLegend(g, (30 * s).toInt(), legendY, s)
-        } finally {
-            g.dispose()
-        }
-
-        val baos = ByteArrayOutputStream()
-        ImageIO.write(img, "png", baos)
-        baos.toByteArray()
+    private companion object {
+        const val BASE_W = 800
+        const val BASE_H = 500
+        const val GRID_STEP = 40
+        const val MIN_GRID_STEP = 20
+        const val FRAME_MARGIN = 20
+        const val FRAME_STROKE = 3
+        const val TITLE_FONT = 18
+        const val TEXT_FONT = 14
+        const val TEXT_X = 30
+        const val TITLE_Y = 40
+        const val STATE_Y = 60
+        const val VER_Y = 80
+        const val LEGEND_Y_OFFSET = 60
+        const val LEGEND_LABEL_DX = 14
+        const val LEGEND_LABEL_DY = 5
+        const val LEGEND_STEP = 80
+        const val DOT_RADIUS = 8
+        const val MIN_SCALE = 0.1
+        const val DEFAULT_SCALE = 1.0
+        val bg = Color(15, 17, 21)
+        val grid = Color(32, 38, 50)
+        val frameColor = Color(96, 165, 250)
+        val textColor = Color(203, 213, 225)
+        val freeColor = Color(34, 197, 94)
+        val holdColor = Color(234, 179, 8)
+        val bookedColor = Color(239, 68, 68)
     }
 
+    override suspend fun render(clubId: Long, startUtc: String, scale: Double, stateKey: String): ByteArray =
+        withContext(Dispatchers.Default) {
+            val s = if (scale.isFinite() && scale > MIN_SCALE) scale else DEFAULT_SCALE
+            val w = (BASE_W * s).toInt()
+            val h = (BASE_H * s).toInt()
+
+            val img = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+            val g = img.createGraphics()
+            try {
+                g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+                // фон
+                g.color = bg
+                g.fillRect(0, 0, w, h)
+
+                // сетка
+                g.color = grid
+                val step = (GRID_STEP * s).toInt().coerceAtLeast(MIN_GRID_STEP)
+                var x = 0
+                while (x < w) {
+                    g.drawLine(x, 0, x, h)
+                    x += step
+                }
+                var y = 0
+                while (y < h) {
+                    g.drawLine(0, y, w, y)
+                    y += step
+                }
+
+                // рамка зала
+                g.color = frameColor
+                g.stroke = BasicStroke((FRAME_STROKE * s).toFloat())
+                g.drawRect(
+                    (FRAME_MARGIN * s).toInt(),
+                    (FRAME_MARGIN * s).toInt(),
+                    (w - 2 * FRAME_MARGIN * s).toInt(),
+                    (h - 2 * FRAME_MARGIN * s).toInt(),
+                )
+
+                // подписи
+                g.font = Font("SansSerif", Font.BOLD, (TITLE_FONT * s).toInt())
+                g.color = textColor
+                g.drawString("Club #$clubId  •  Night: $startUtc", (TEXT_X * s).toInt(), (TITLE_Y * s).toInt())
+                g.font = Font("SansSerif", Font.PLAIN, (TEXT_FONT * s).toInt())
+                g.drawString("state: $stateKey", (TEXT_X * s).toInt(), (STATE_Y * s).toInt())
+                val ver = System.getenv("HALL_BASE_IMAGE_VERSION") ?: "1"
+                g.drawString("v$ver  •  scale=${"%.1f".format(s)}", (TEXT_X * s).toInt(), (VER_Y * s).toInt())
+
+                // легенда
+                val legendY = h - (LEGEND_Y_OFFSET * s).toInt()
+                drawLegend(g, (TEXT_X * s).toInt(), legendY, s)
+            } finally {
+                g.dispose()
+            }
+
+            val baos = ByteArrayOutputStream()
+            ImageIO.write(img, "png", baos)
+            baos.toByteArray()
+        }
+
     private fun drawLegend(g: java.awt.Graphics2D, x: Int, y: Int, s: Double) {
-        val r = (8 * s).toInt()
+        val r = (DOT_RADIUS * s).toInt()
+
         fun dot(cx: Int, cy: Int, color: Color) {
             g.color = color
             g.fillOval(cx - r, cy - r, 2 * r, 2 * r)
         }
         var cx = x
         val cy = y
-        g.font = Font("SansSerif", Font.PLAIN, (14 * s).toInt())
-        dot(cx, cy, Color(34, 197, 94))
-        g.color = Color(203, 213, 225)
-        g.drawString("FREE", cx + (14 * s).toInt(), cy + (5 * s).toInt())
-        cx += (80 * s).toInt()
-        dot(cx, cy, Color(234, 179, 8))
-        g.color = Color(203, 213, 225)
-        g.drawString("HOLD", cx + (14 * s).toInt(), cy + (5 * s).toInt())
-        cx += (80 * s).toInt()
-        dot(cx, cy, Color(239, 68, 68))
-        g.color = Color(203, 213, 225)
-        g.drawString("BOOKED", cx + (14 * s).toInt(), cy + (5 * s).toInt())
+        g.font = Font("SansSerif", Font.PLAIN, (TEXT_FONT * s).toInt())
+        dot(cx, cy, freeColor)
+        g.color = textColor
+        g.drawString("FREE", cx + (LEGEND_LABEL_DX * s).toInt(), cy + (LEGEND_LABEL_DY * s).toInt())
+        cx += (LEGEND_STEP * s).toInt()
+        dot(cx, cy, holdColor)
+        g.color = textColor
+        g.drawString("HOLD", cx + (LEGEND_LABEL_DX * s).toInt(), cy + (LEGEND_LABEL_DY * s).toInt())
+        cx += (LEGEND_STEP * s).toInt()
+        dot(cx, cy, bookedColor)
+        g.color = textColor
+        g.drawString("BOOKED", cx + (LEGEND_LABEL_DX * s).toInt(), cy + (LEGEND_LABEL_DY * s).toInt())
     }
 }

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/ott/KeyboardFactory.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/ott/KeyboardFactory.kt
@@ -1,3 +1,5 @@
+@file:Suppress("SpreadOperator")
+
 package com.example.bot.telegram.ott
 
 import com.pengrad.telegrambot.model.request.InlineKeyboardButton
@@ -9,17 +11,14 @@ object KeyboardFactory {
      * Пример: клавиатура со столами, где в callback_data — одноразовый токен.
      * @param items пары (label, payload)
      */
-    fun tableKeyboard(
-        service: CallbackTokenService,
-        items: List<Pair<String, BookTableAction>>
-    ): InlineKeyboardMarkup {
-        val buttons = items.map { (label, payload) ->
-            val token = service.issueToken(payload)
-            InlineKeyboardButton(label).callbackData(token)
-        }
+    fun tableKeyboard(service: CallbackTokenService, items: List<Pair<String, BookTableAction>>): InlineKeyboardMarkup {
+        val buttons =
+            items.map { (label, payload) ->
+                val token = service.issueToken(payload)
+                InlineKeyboardButton(label).callbackData(token)
+            }
         // Разложим по рядам по 2 кнопки
         val rows = buttons.chunked(2).map { it.toTypedArray() }.toTypedArray()
         return InlineKeyboardMarkup(*rows)
     }
 }
-

--- a/core-testing/src/test/kotlin/com/example/bot/cache/HallRenderCacheEtagTest.kt
+++ b/core-testing/src/test/kotlin/com/example/bot/cache/HallRenderCacheEtagTest.kt
@@ -1,0 +1,23 @@
+package com.example.bot.cache
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class HallRenderCacheEtagTest {
+
+    @Test
+    fun `returns 304 on If-None-Match`() =
+        runBlocking {
+            val cache = HallRenderCache(maxEntries = 10, ttlSeconds = 60)
+            val key = "k"
+            val first = cache.getOrRender(key, null) { "hello".toByteArray() }
+            require(first is HallRenderCache.Result.Ok)
+            val etag = first.etag
+
+            val second = cache.getOrRender(key, etag) { "updated".toByteArray() }
+            assert(second is HallRenderCache.Result.NotModified)
+            val nm = second as HallRenderCache.Result.NotModified
+            assertEquals(etag, nm.etag)
+        }
+}

--- a/core-testing/src/test/kotlin/com/example/bot/ott/OneTimeTokenStoreTest.kt
+++ b/core-testing/src/test/kotlin/com/example/bot/ott/OneTimeTokenStoreTest.kt
@@ -1,0 +1,34 @@
+package com.example.bot.ott
+
+import com.example.bot.telegram.ott.BookTableAction
+import com.example.bot.telegram.ott.InMemoryOneTimeTokenStore
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class OneTimeTokenStoreTest {
+
+    @Test
+    fun `issue-consume once`() {
+        val store = InMemoryOneTimeTokenStore(ttlSeconds = 60, maxEntries = 100)
+        val token = store.issue(BookTableAction(1L, "2025-12-31T22:00:00Z", 101L))
+        val p1 = store.consume(token)
+        assertNotNull(p1)
+        val p2 = store.consume(token)
+        assertNull(p2)
+    }
+
+    @Test
+    fun `expired token returns null`() {
+        val store = InMemoryOneTimeTokenStore(ttlSeconds = 30, maxEntries = 100)
+        val ttlField = InMemoryOneTimeTokenStore::class.java.getDeclaredField("ttl")
+        ttlField.isAccessible = true
+        ttlField.set(store, Duration.ofSeconds(1))
+        val token = store.issue(BookTableAction(1L, "t", 1L))
+        // имитация TTL: ждём > 1с
+        Thread.sleep(1200)
+        val p = store.consume(token)
+        assertNull(p)
+    }
+}


### PR DESCRIPTION
## Summary
- expand `.env.example` with rate-limit, hot-path, token store, cache and database tuning knobs
- expose Micrometer registry and bind existing atomic metrics
- document per-chat rate-limit extractor and add TTL/ETag integration tests
- centralize hall cache timing constants and streamline cache lookups
- clarify Netty server tuning parameter and document max request size default
- flatten one-time token store cleanup logic and extract hall renderer constants
- suppress spread operator warnings and remove magic numbers from demo code

## Testing
- `./gradlew -q formatAll`
- `./gradlew staticCheck --console=plain` *(fails: detekt violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c8110beb34832195b60a7257683708