### PR TITLE
Refactor bot limits into shared constants

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/config/BotLimits.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/config/BotLimits.kt
@@ -1,0 +1,28 @@
+package com.example.bot.config
+
+import java.time.Duration
+
+object BotLimits {
+    // Idempotency
+    val notifyIdempotencyTtl: Duration = Duration.ofHours(24)
+    val notifyIdempotencyCleanupSize: Int = 50_000
+
+    // One-Time Tokens (OTT)
+    val ottTokenTtl: Duration = Duration.ofSeconds(300)
+    val ottTokenMinTtl: Duration = Duration.ofSeconds(30)
+    val ottMaxEntries: Int = 100_000
+    val ottMinEntries: Int = 1
+    val ottCleanupAbsoluteThreshold: Int = 10_000
+    val ottTokenBaseBytes: Int = 20
+    val ottTokenExtraBytesRange: IntRange = 0..4
+    val ottTokenMaxBase64Length: Int = 64
+
+    // Notify sender / backoff
+    val notifySendBaseBackoff: Duration = Duration.ofMillis(500)
+    val notifySendMaxBackoff: Duration = Duration.ofMillis(15_000)
+    val notifySendJitter: Duration = Duration.ofMillis(100)
+    val notifySendMaxAttempts: Int = 3
+    val notifyRetryAfterFallback: Duration = Duration.ofSeconds(1)
+    val notifyBackoffMaxShift: Int = 20
+    val notifyDurationPercentiles: DoubleArray = doubleArrayOf(0.5, 0.95)
+}


### PR DESCRIPTION
## Summary
- extract reusable bot limit constants into a new `BotLimits` object
- replace magic literals in the notify idempotency store, one-time token store, and notify sender with the shared constants and `Duration`
- switch HTTP status handling in notify sender to `HttpStatusCode` equivalents

## Testing
- ./gradlew :app-bot:check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ca90ff8db4832189e9917e335e1556