### PR TITLE
Fix detekt warnings in app-bot module

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/Application.kt
@@ -23,13 +23,22 @@ import com.pengrad.telegrambot.request.SendMessage
 import io.ktor.server.application.Application
 import io.ktor.server.routing.routing
 
+private const val DEMO_STATE_KEY = "v1"
+private const val DEMO_CLUB_ID = 1L
+private const val DEMO_START_UTC = "2025-12-31T22:00:00Z"
+private const val DEMO_TABLE_ID_1 = 101L
+private const val DEMO_TABLE_ID_2 = 102L
+private const val DEMO_TABLE_ID_3 = 103L
+private val DEMO_TABLE_IDS = listOf(DEMO_TABLE_ID_1, DEMO_TABLE_ID_2, DEMO_TABLE_ID_3)
+private const val DEMO_FALLBACK_TOKEN = "000000:DEV"
+
 @Suppress("unused")
 fun Application.module() {
     // demo constants (чтобы не было «магических» чисел)
-    val demoStateKey = "v1"
-    val demoClubId = 1L
-    val demoStartUtc = "2025-12-31T22:00:00Z"
-    val demoTableIds = listOf(101L, 102L, 103L)
+    val demoStateKey = DEMO_STATE_KEY
+    val demoClubId = DEMO_CLUB_ID
+    val demoStartUtc = DEMO_START_UTC
+    val demoTableIds = DEMO_TABLE_IDS
 
     // 0) Тюнинг сервера (лимиты размера запроса и пр.)
     installServerTuning()
@@ -53,7 +62,7 @@ fun Application.module() {
     }
 
     // Telegram bot demo integration
-    val telegramToken = System.getenv("TELEGRAM_BOT_TOKEN") ?: "000000:DEV"
+    val telegramToken = System.getenv("TELEGRAM_BOT_TOKEN") ?: DEMO_FALLBACK_TOKEN
     val bot = TelegramBot(telegramToken)
     val ottService = CallbackTokenService()
     val callbackHandler = CallbackQueryHandler(bot, ottService)

--- a/app-bot/src/main/kotlin/com/example/bot/config/BotLimits.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/config/BotLimits.kt
@@ -5,24 +5,24 @@ import java.time.Duration
 object BotLimits {
     // Idempotency
     val notifyIdempotencyTtl: Duration = Duration.ofHours(24)
-    val notifyIdempotencyCleanupSize: Int = 50_000
+    const val notifyIdempotencyCleanupSize: Int = 50_000
 
     // One-Time Tokens (OTT)
     val ottTokenTtl: Duration = Duration.ofSeconds(300)
     val ottTokenMinTtl: Duration = Duration.ofSeconds(30)
-    val ottMaxEntries: Int = 100_000
-    val ottMinEntries: Int = 1
-    val ottCleanupAbsoluteThreshold: Int = 10_000
-    val ottTokenBaseBytes: Int = 20
+    const val ottMaxEntries: Int = 100_000
+    const val ottMinEntries: Int = 1
+    const val ottCleanupAbsoluteThreshold: Int = 10_000
+    const val ottTokenBaseBytes: Int = 20
     val ottTokenExtraBytesRange: IntRange = 0..4
-    val ottTokenMaxBase64Length: Int = 64
+    const val ottTokenMaxBase64Length: Int = 64
 
     // Notify sender / backoff
     val notifySendBaseBackoff: Duration = Duration.ofMillis(500)
     val notifySendMaxBackoff: Duration = Duration.ofMillis(15_000)
     val notifySendJitter: Duration = Duration.ofMillis(100)
-    val notifySendMaxAttempts: Int = 3
+    const val notifySendMaxAttempts: Int = 3
     val notifyRetryAfterFallback: Duration = Duration.ofSeconds(1)
-    val notifyBackoffMaxShift: Int = 20
+    const val notifyBackoffMaxShift: Int = 20
     val notifyDurationPercentiles: DoubleArray = doubleArrayOf(0.5, 0.95)
 }

--- a/app-bot/src/main/kotlin/com/example/bot/plugins/HotPathLimiter.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/plugins/HotPathLimiter.kt
@@ -13,6 +13,10 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
+private const val MIN_CONFIG_PARALLELISM = 2
+private const val MIN_ENV_PARALLELISM = 4
+private const val DEFAULT_RETRY_AFTER_SECONDS = 1
+
 /**
  * Конфигурация плагина лимитирования «горячих» путей.
  */
@@ -25,7 +29,7 @@ class HotPathLimiterConfig {
     /**
      * Максимум параллельных обработок для каждого совпадающего пути.
      */
-    var maxConcurrent: Int = Runtime.getRuntime().availableProcessors().coerceAtLeast(2)
+    var maxConcurrent: Int = Runtime.getRuntime().availableProcessors().coerceAtLeast(MIN_CONFIG_PARALLELISM)
 
     /**
      * Заголовок с информацией о лимитах (например, Retry-After).
@@ -35,7 +39,7 @@ class HotPathLimiterConfig {
     /**
      * Значение Retry-After (секунды) при отказе.
      */
-    var retryAfterSeconds: Int = 1
+    var retryAfterSeconds: Int = DEFAULT_RETRY_AFTER_SECONDS
 }
 
 /**
@@ -99,7 +103,8 @@ fun Application.installHotPathLimiterDefaults() {
     install(HotPathLimiter) {
         pathPrefixes = defaults
         maxConcurrent = System.getenv("HOT_PATH_MAX_CONCURRENT")?.toIntOrNull()
-            ?: Runtime.getRuntime().availableProcessors().coerceAtLeast(4)
-        retryAfterSeconds = System.getenv("HOT_PATH_RETRY_AFTER_SEC")?.toIntOrNull() ?: 1
+            ?: Runtime.getRuntime().availableProcessors().coerceAtLeast(MIN_ENV_PARALLELISM)
+        retryAfterSeconds =
+            System.getenv("HOT_PATH_RETRY_AFTER_SEC")?.toIntOrNull() ?: DEFAULT_RETRY_AFTER_SECONDS
     }
 }

--- a/app-bot/src/main/kotlin/com/example/bot/plugins/RateLimitPlugin.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/plugins/RateLimitPlugin.kt
@@ -114,16 +114,15 @@ val RateLimitPlugin =
     }
 
 private fun clientIp(call: io.ktor.server.application.ApplicationCall): String {
-    val xff = call.request.header("X-Forwarded-For")
-    if (!xff.isNullOrBlank()) {
-        val first = xff.split(',').first().trim()
-        if (first.isNotEmpty()) return first
-    }
-    val real = call.request.header("X-Real-IP")
-    if (!real.isNullOrBlank()) {
-        return real
-    }
-    return call.request.host() + ":" + call.request.port()
+    val forwarded =
+        call.request.header("X-Forwarded-For")
+            ?.split(',')
+            ?.firstOrNull()
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+    val real = call.request.header("X-Real-IP")?.takeIf { it.isNotBlank() }
+    val hostWithPort = "${call.request.host()}:${call.request.port()}"
+    return forwarded ?: real ?: hostWithPort
 }
 
 fun Application.installRateLimitPluginDefaults() {

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/NotifyIdempotencyStore.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/NotifyIdempotencyStore.kt
@@ -25,12 +25,20 @@ class InMemoryNotifyIdempotencyStore(
 
     override fun seen(key: String): Boolean {
         cleanupIfNeeded()
-        val entry = map[key] ?: return false
-        if (Instant.now().isAfter(entry.timestamp.plus(ttl))) {
-            map.remove(key)
-            return false
-        }
-        return true
+        val entry = map[key]
+        val isSeen =
+            if (entry == null) {
+                false
+            } else {
+                val expired = Instant.now().isAfter(entry.timestamp.plus(ttl))
+                if (expired) {
+                    map.remove(key)
+                    false
+                } else {
+                    true
+                }
+            }
+        return isSeen
     }
 
     override fun mark(key: String) {

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/ott/CallbackTokenService.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/ott/CallbackTokenService.kt
@@ -30,21 +30,28 @@ class CallbackQueryHandler(
 ) {
 
     fun handle(update: Update) {
-        val cq: CallbackQuery = update.callbackQuery() ?: return
-        val token: String = cq.data() ?: return
-        val payload: OttPayload = tokenService.consume(token) ?: run {
-            // устарело/повтор — показываем alert, ничего не делаем
-            bot.execute(
-                AnswerCallbackQuery(cq.id())
-                    .text("Кнопка устарела, обновите экран.")
-                    .showAlert(true)
-            )
-            return
-        }
+        val callbackQuery: CallbackQuery? = update.callbackQuery()
+        val token: String? = callbackQuery?.data()
+        val payload: OttPayload? = token?.let(tokenService::consume)
 
-        when (payload) {
-            is BookTableAction -> handleBookTable(cq, payload)
-            // добавляйте другие типы payload тут
+        return when {
+            callbackQuery == null -> Unit
+            token == null -> Unit
+            payload == null -> {
+                // устарело/повтор — показываем alert, ничего не делаем
+                bot.execute(
+                    AnswerCallbackQuery(callbackQuery.id())
+                        .text("Кнопка устарела, обновите экран.")
+                        .showAlert(true)
+                )
+                Unit
+            }
+            else -> {
+                when (payload) {
+                    is BookTableAction -> handleBookTable(callbackQuery, payload)
+                    // добавляйте другие типы payload тут
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- promote runtime-independent `BotLimits` scalars to `const val` and name rate-limit thresholds in the token bucket and notifier
- extract reusable defaults for hot-path limiter, hall rendering routes, and application demo data to eliminate detekt magic numbers
- streamline `clientIp` guard flow and ensure the callback handler branches return `Unit`

## Testing
- ./gradlew :app-bot:compileKotlin
- ./gradlew :app-bot:detektCli --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ca93e9040483219ed60e61efebe2e2