### PR TITLE
Add Docker-aware integration test gating

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,8 @@ jobs:
           echo "postgres not ready" && exit 1
 
       - name: Run unit & integration tests
+        env:
+          CI: "true"
         run: ./gradlew clean test --console=plain
 
       - name: Upload test reports

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Enable verbose logging:
 
 Test reports are generated under `build/reports/tests/test/index.html`.
 
+## Запуск интеграционных тестов
+
+- Локально без Docker: `./gradlew clean build detekt` — интеграционные тесты автоматически пропустятся.
+- Локально с Docker: `./gradlew clean build test detekt -PrunIT=true`.
+- В CI интеграционные тесты запускаются автоматически (`CI=true`).
+
 ## Perf smoke
 
 Сборка и запуск:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,8 +39,17 @@ subprojects {
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
         apply(from = rootProject.file("gradle/detekt-cli.gradle.kts"))
         apply(from = rootProject.file("gradle/ktlint-cli.gradle.kts"))
-        tasks.withType<Test>().configureEach {
-            useJUnitPlatform()
+    }
+
+    tasks.withType<Test>().configureEach {
+        useJUnitPlatform()
+        val isCi = project.providers.environmentVariable("CI").orElse("false").map { it.equals("true", true) }
+        val runIt = project.providers.gradleProperty("runIT").orElse("false").map { it.equals("true", true) }
+        doFirst {
+            if (!isCi.get() && !runIt.get()) {
+                logger.lifecycle("Excluding @Tag(\"it\") tests (no CI and -PrunIT not set)")
+                systemProperty("junit.jupiter.tags.exclude", "it")
+            }
         }
     }
 }

--- a/core-data/src/test/kotlin/com/example/bot/data/booking/core/AuditLogRepositoryIT.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/booking/core/AuditLogRepositoryIT.kt
@@ -11,8 +11,12 @@ import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 class AuditLogRepositoryIT : PostgresIntegrationTest() {
     @Test
     fun `log writes audit record`() = runBlocking {

--- a/core-data/src/test/kotlin/com/example/bot/data/booking/core/BookingHoldRepositoryIT.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/booking/core/BookingHoldRepositoryIT.kt
@@ -16,8 +16,12 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 class BookingHoldRepositoryIT : PostgresIntegrationTest() {
     @Test
     fun `create hold respects ttl`() = runBlocking {

--- a/core-data/src/test/kotlin/com/example/bot/data/booking/core/BookingRepositoryIT.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/booking/core/BookingRepositoryIT.kt
@@ -16,8 +16,12 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 class BookingRepositoryIT : PostgresIntegrationTest() {
     private val clock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC)
     private val bookingRepo by lazy { BookingRepository(database, clock) }

--- a/core-data/src/test/kotlin/com/example/bot/data/booking/core/OutboxRepositoryIT.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/booking/core/OutboxRepositoryIT.kt
@@ -11,8 +11,12 @@ import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 class OutboxRepositoryIT : PostgresIntegrationTest() {
     @Test
     fun `enqueue pick and update outbox`() = runBlocking {

--- a/core-data/src/test/kotlin/com/example/bot/data/booking/core/PostgresIntegrationTest.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/booking/core/PostgresIntegrationTest.kt
@@ -6,11 +6,15 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 @Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class PostgresIntegrationTest {

--- a/core-data/src/test/kotlin/com/example/bot/data/migration/FlywayVendorSmokeTest.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/migration/FlywayVendorSmokeTest.kt
@@ -5,13 +5,17 @@ import com.zaxxer.hikari.HikariDataSource
 import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.PostgreSQLContainer
 import java.math.BigDecimal
 import java.sql.Connection
 import java.util.UUID
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 class FlywayVendorSmokeTest {
     private val resourcesToClose = mutableListOf<AutoCloseable>()
 

--- a/core-domain/build.gradle.kts
+++ b/core-domain/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     testImplementation(libs.kotest.runner)
     testImplementation(libs.kotest.assertions)
     testImplementation(libs.mockk)
+    testImplementation(projects.coreTesting)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
 }

--- a/core-domain/src/test/kotlin/com/example/bot/availability/AvailabilityCalendarTest.kt
+++ b/core-domain/src/test/kotlin/com/example/bot/availability/AvailabilityCalendarTest.kt
@@ -9,6 +9,7 @@ import com.example.bot.time.OperatingRulesResolver
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Testcontainers
@@ -17,7 +18,10 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 @Testcontainers
 class AvailabilityCalendarTest {
 

--- a/core-domain/src/test/kotlin/com/example/bot/availability/AvailabilityPerfTest.kt
+++ b/core-domain/src/test/kotlin/com/example/bot/availability/AvailabilityPerfTest.kt
@@ -8,6 +8,7 @@ import com.example.bot.time.ClubHour
 import com.example.bot.time.OperatingRulesResolver
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Testcontainers
@@ -16,7 +17,10 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlin.math.ceil
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 @Testcontainers
 class AvailabilityPerfTest {
 

--- a/core-domain/src/test/kotlin/com/example/bot/availability/AvailabilityTablesTest.kt
+++ b/core-domain/src/test/kotlin/com/example/bot/availability/AvailabilityTablesTest.kt
@@ -8,6 +8,7 @@ import com.example.bot.time.ClubHour
 import com.example.bot.time.OperatingRulesResolver
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Testcontainers
@@ -15,7 +16,10 @@ import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 @Testcontainers
 class AvailabilityTablesTest {
 

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
     implementation(projects.coreDomain)
     implementation(projects.coreData)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.junit.jupiter)
+    implementation(libs.testcontainers.junit)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotest.runner)
     testImplementation(libs.kotest.assertions)

--- a/core-testing/src/main/kotlin/testing/RequiresDocker.kt
+++ b/core-testing/src/main/kotlin/testing/RequiresDocker.kt
@@ -1,0 +1,22 @@
+package testing
+import org.junit.jupiter.api.extension.ConditionEvaluationResult
+import org.junit.jupiter.api.extension.ExecutionCondition
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ExtendWith(DockerRequiredCondition::class)
+annotation class RequiresDocker
+
+class DockerRequiredCondition : ExecutionCondition {
+    override fun evaluateExecutionCondition(ctx: ExtensionContext): ConditionEvaluationResult {
+        val available = try {
+            org.testcontainers.DockerClientFactory.instance().isDockerAvailable()
+        } catch (_: Throwable) { false }
+        return if (available)
+            ConditionEvaluationResult.enabled("Docker available")
+        else
+            ConditionEvaluationResult.disabled("Docker not available, skipping integration test")
+    }
+}

--- a/core-testing/src/test/kotlin/com/example/bot/music/MigrationTest.kt
+++ b/core-testing/src/test/kotlin/com/example/bot/music/MigrationTest.kt
@@ -2,10 +2,14 @@ package com.example.bot.music
 
 import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
+import testing.RequiresDocker
 
 /** Ensures music migrations apply successfully. */
+@RequiresDocker
+@Tag("it")
 class MigrationTest {
     @Test
     fun `migrations apply`() {

--- a/core-testing/src/test/kotlin/com/example/bot/music/RepositoryTest.kt
+++ b/core-testing/src/test/kotlin/com/example/bot/music/RepositoryTest.kt
@@ -5,10 +5,14 @@ import kotlinx.coroutines.runBlocking
 import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import java.time.Instant
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 class RepositoryTest {
     @Test
     fun `create and list`() =

--- a/core-testing/src/test/kotlin/com/example/bot/notifications/OutboxRateLimitIT.kt
+++ b/core-testing/src/test/kotlin/com/example/bot/notifications/OutboxRateLimitIT.kt
@@ -15,11 +15,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.junit.jupiter.api.Tag
 import java.time.OffsetDateTime
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import testing.RequiresDocker
 
+@RequiresDocker
+@Tag("it")
 class OutboxRateLimitIT :
     StringSpec({
         "worker respects rate limits" {

--- a/core-testing/src/test/kotlin/com/example/notify/OutboxWorkerSmokeTest.kt
+++ b/core-testing/src/test/kotlin/com/example/notify/OutboxWorkerSmokeTest.kt
@@ -23,9 +23,13 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import testing.RequiresDocker
 import kotlin.test.assertEquals
 
+@RequiresDocker
+@Tag("it")
 class OutboxWorkerSmokeTest : PgContainer() {
     @BeforeEach
     fun prepare() {


### PR DESCRIPTION
## Summary
- add a shared `@RequiresDocker` annotation to gate Docker-dependent tests
- tag integration suites and configure Gradle to exclude them unless CI or -PrunIT=true
- enable CI builds to run integration tests and document local execution instructions

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cde324c1fc83219b029419f4e04b4e