### PR TITLE
Add club data repositories, CSV import, and integration tests

### DIFF
--- a/core-data/src/main/kotlin/com/example/bot/data/club/EventRepositoryImpl.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/club/EventRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package com.example.bot.data.club
+
+import com.example.bot.club.Event
+import com.example.bot.club.EventRepository
+import com.example.bot.data.booking.EventsTable
+import com.example.bot.data.db.withTxRetry
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.ranges.ClosedRange
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class EventRepositoryImpl(private val database: Database) : EventRepository {
+    override suspend fun listByClub(clubId: Long, dateRange: ClosedRange<Instant>): List<Event> {
+        val start = dateRange.start.atOffset(ZoneOffset.UTC)
+        val end = dateRange.endInclusive.atOffset(ZoneOffset.UTC)
+        return withTxRetry {
+            transaction(database) {
+                EventsTable
+                    .select { (EventsTable.clubId eq clubId) and EventsTable.startAt.between(start, end) }
+                    .orderBy(EventsTable.startAt, SortOrder.ASC)
+                    .map { it.toEvent() }
+            }
+        }
+    }
+
+    override suspend fun get(id: Long): Event? {
+        return withTxRetry {
+            transaction(database) {
+                EventsTable
+                    .select { EventsTable.id eq id }
+                    .firstOrNull()
+                    ?.toEvent()
+            }
+        }
+    }
+
+    private fun ResultRow.toEvent(): Event {
+        return Event(
+            id = this[EventsTable.id],
+            clubId = this[EventsTable.clubId],
+            title = this[EventsTable.title],
+            startAt = this[EventsTable.startAt].toInstant(),
+            endAt = this[EventsTable.endAt].toInstant(),
+            isSpecial = this[EventsTable.isSpecial],
+            posterUrl = this[EventsTable.posterUrl],
+        )
+    }
+}

--- a/core-data/src/main/kotlin/com/example/bot/data/club/GuestListCsvParser.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/club/GuestListCsvParser.kt
@@ -1,0 +1,82 @@
+package com.example.bot.data.club
+
+import com.example.bot.club.GuestListEntryStatus
+import com.example.bot.club.ParsedGuest
+import com.example.bot.club.RejectedRow
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
+
+/** Result of parsing a guest list import file. */
+data class GuestListParseResult(val rows: List<ParsedGuest>, val rejected: List<RejectedRow>)
+
+/**
+ * Parser for guest list CSV/TSV files with header `name,phone,guests_count,notes`.
+ */
+class GuestListCsvParser {
+    fun parse(input: InputStream): GuestListParseResult {
+        BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8)).use { reader ->
+            val headerLine = requireNotNull(reader.readLine()) { "Empty import file" }
+            val delimiter = detectDelimiter(headerLine)
+            val headers = headerLine.split(delimiter).map { it.trim().lowercase() }
+            require(headers == EXPECTED_HEADER) { "Invalid header: ${'$'}headerLine" }
+            val parsed = mutableListOf<ParsedGuest>()
+            val rejected = mutableListOf<RejectedRow>()
+            var lineNumber = 1
+            reader.lineSequence().forEach { rawLine ->
+                lineNumber += 1
+                val line = rawLine.trimEnd()
+                if (line.isEmpty()) {
+                    return@forEach
+                }
+                val tokens = line.split(delimiter, ignoreCase = false, limit = COLUMN_COUNT)
+                if (tokens.size < MIN_COLUMNS) {
+                    rejected += RejectedRow(lineNumber, "Expected at least $MIN_COLUMNS columns")
+                    return@forEach
+                }
+                val name = tokens[NAME_INDEX].trim()
+                val phoneRaw = tokens.getOrNull(PHONE_INDEX)?.trim()
+                val guestsToken = tokens.getOrNull(GUESTS_INDEX)?.trim()
+                val notes = tokens.getOrNull(NOTES_INDEX)?.trim()?.takeIf { it.isNotEmpty() }
+                val guestsCount = guestsToken?.toIntOrNull()
+                if (guestsCount == null) {
+                    rejected += RejectedRow(lineNumber, "guests_count must be an integer")
+                    return@forEach
+                }
+                val validation = validateEntryInput(name, phoneRaw, guestsCount, notes, DEFAULT_STATUS)
+                when (validation) {
+                    is EntryValidationOutcome.Invalid -> rejected += RejectedRow(lineNumber, validation.reason)
+                    is EntryValidationOutcome.Valid -> parsed +=
+                        ParsedGuest(
+                            lineNumber = lineNumber,
+                            name = validation.name,
+                            phone = validation.phone,
+                            guestsCount = validation.guestsCount,
+                            notes = validation.notes,
+                        )
+                }
+            }
+            return GuestListParseResult(parsed.toList(), rejected.toList())
+        }
+    }
+
+    private fun detectDelimiter(header: String): Char {
+        return when {
+            header.contains('\t') -> '\t'
+            header.contains(',') -> ','
+            else -> error("Unsupported delimiter in header")
+        }
+    }
+
+    companion object {
+        private val EXPECTED_HEADER = listOf("name", "phone", "guests_count", "notes")
+        private const val COLUMN_COUNT: Int = 4
+        private const val MIN_COLUMNS: Int = 3
+        private const val NAME_INDEX: Int = 0
+        private const val PHONE_INDEX: Int = 1
+        private const val GUESTS_INDEX: Int = 2
+        private const val NOTES_INDEX: Int = 3
+        private val DEFAULT_STATUS = GuestListEntryStatus.PLANNED
+    }
+}

--- a/core-data/src/main/kotlin/com/example/bot/data/club/GuestListRepositoryImpl.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/club/GuestListRepositoryImpl.kt
@@ -1,0 +1,265 @@
+package com.example.bot.data.club
+
+import com.example.bot.club.BulkImportResult
+import com.example.bot.club.GuestList
+import com.example.bot.club.GuestListEntry
+import com.example.bot.club.GuestListEntryStatus
+import com.example.bot.club.GuestListOwnerType
+import com.example.bot.club.GuestListRepository
+import com.example.bot.club.GuestListStatus
+import com.example.bot.club.ParsedGuest
+import com.example.bot.club.RejectedRow
+import com.example.bot.data.db.withTxRetry
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.batchInsert
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+class GuestListRepositoryImpl(
+    private val database: Database,
+    private val clock: Clock = Clock.systemUTC(),
+) : GuestListRepository {
+    override suspend fun createList(
+        clubId: Long,
+        eventId: Long,
+        ownerType: GuestListOwnerType,
+        ownerUserId: Long,
+        title: String,
+        capacity: Int,
+        arrivalWindowStart: Instant?,
+        arrivalWindowEnd: Instant?,
+        status: GuestListStatus,
+    ): GuestList {
+        return withTxRetry {
+            transaction(database) {
+                val createdAt = clock.instant().atOffset(ZoneOffset.UTC)
+                GuestListsTable
+                    .insert {
+                        it[GuestListsTable.clubId] = clubId
+                        it[GuestListsTable.eventId] = eventId
+                        it[GuestListsTable.ownerType] = ownerType.name
+                        it[GuestListsTable.ownerUserId] = ownerUserId
+                        it[GuestListsTable.title] = title
+                        it[GuestListsTable.capacity] = capacity
+                        it[GuestListsTable.arrivalWindowStart] = arrivalWindowStart?.atOffset(ZoneOffset.UTC)
+                        it[GuestListsTable.arrivalWindowEnd] = arrivalWindowEnd?.atOffset(ZoneOffset.UTC)
+                        it[GuestListsTable.status] = status.name
+                        it[GuestListsTable.createdAt] = createdAt
+                    }
+                    .resultedValues!!
+                    .single()
+                    .toGuestList()
+            }
+        }
+    }
+
+    override suspend fun getList(id: Long): GuestList? {
+        return withTxRetry {
+            transaction(database) {
+                GuestListsTable
+                    .select { GuestListsTable.id eq id }
+                    .firstOrNull()
+                    ?.toGuestList()
+            }
+        }
+    }
+
+    override suspend fun listListsByClub(clubId: Long, page: Int, size: Int): List<GuestList> {
+        require(page >= 0) { "page must be non-negative" }
+        require(size > 0) { "size must be positive" }
+        val offset = page.toLong() * size
+        require(offset <= Int.MAX_VALUE) { "page too large" }
+        return withTxRetry {
+            transaction(database) {
+                GuestListsTable
+                    .select { GuestListsTable.clubId eq clubId }
+                    .orderBy(GuestListsTable.createdAt, SortOrder.DESC)
+                    .limit(size, offset)
+                    .map { it.toGuestList() }
+            }
+        }
+    }
+
+    override suspend fun addEntry(
+        listId: Long,
+        fullName: String,
+        phone: String?,
+        guestsCount: Int,
+        notes: String?,
+        status: GuestListEntryStatus,
+    ): GuestListEntry {
+        val validation = validateEntryInput(fullName, phone, guestsCount, notes, status)
+        val valid =
+            when (validation) {
+                is EntryValidationOutcome.Invalid -> throw IllegalArgumentException(validation.reason)
+                is EntryValidationOutcome.Valid -> validation
+            }
+        return withTxRetry {
+            transaction(database) {
+                val inserted =
+                    GuestListEntriesTable
+                        .insert {
+                            it[GuestListEntriesTable.guestListId] = listId
+                            it[GuestListEntriesTable.fullName] = valid.name
+                            it[GuestListEntriesTable.phone] = valid.phone
+                            it[GuestListEntriesTable.plusOnesAllowed] = valid.guestsCount - MIN_GUESTS_PER_ENTRY
+                            it[GuestListEntriesTable.plusOnesUsed] = DEFAULT_PLUS_ONES_USED
+                            it[GuestListEntriesTable.category] = DEFAULT_CATEGORY
+                            it[GuestListEntriesTable.comment] = valid.notes
+                            it[GuestListEntriesTable.status] = valid.status.name
+                            if (valid.status == GuestListEntryStatus.CHECKED_IN) {
+                                it[GuestListEntriesTable.checkedInAt] = clock.instant().atOffset(ZoneOffset.UTC)
+                                it[GuestListEntriesTable.checkedInBy] = null
+                            } else {
+                                it[GuestListEntriesTable.checkedInAt] = null
+                                it[GuestListEntriesTable.checkedInBy] = null
+                            }
+                        }
+                        .resultedValues!!
+                        .single()
+                inserted.toGuestListEntry()
+            }
+        }
+    }
+
+    override suspend fun setEntryStatus(
+        entryId: Long,
+        status: GuestListEntryStatus,
+        checkedInBy: Long?,
+        at: Instant?,
+    ): GuestListEntry? {
+        return withTxRetry {
+            transaction(database) {
+                val checkedAt =
+                    if (status == GuestListEntryStatus.CHECKED_IN) {
+                        (at ?: clock.instant()).atOffset(ZoneOffset.UTC)
+                    } else {
+                        null
+                    }
+                val actorId = checkedInBy
+                val updated =
+                    GuestListEntriesTable.update({ GuestListEntriesTable.id eq entryId }) {
+                        it[GuestListEntriesTable.status] = status.name
+                        it[checkedInAt] = checkedAt
+                        it[GuestListEntriesTable.checkedInBy] = if (checkedAt != null) actorId else null
+                    }
+                if (updated == 0) {
+                    null
+                } else {
+                    GuestListEntriesTable
+                        .select { GuestListEntriesTable.id eq entryId }
+                        .single()
+                        .toGuestListEntry()
+                }
+            }
+        }
+    }
+
+    override suspend fun listEntries(
+        listId: Long,
+        page: Int,
+        size: Int,
+        statusFilter: GuestListEntryStatus?,
+    ): List<GuestListEntry> {
+        require(page >= 0) { "page must be non-negative" }
+        require(size > 0) { "size must be positive" }
+        val offset = page.toLong() * size
+        require(offset <= Int.MAX_VALUE) { "page too large" }
+        return withTxRetry {
+            transaction(database) {
+                val baseQuery = GuestListEntriesTable.select { GuestListEntriesTable.guestListId eq listId }
+                val filteredQuery =
+                    if (statusFilter != null) {
+                        baseQuery.andWhere { GuestListEntriesTable.status eq statusFilter.name }
+                    } else {
+                        baseQuery
+                    }
+                filteredQuery
+                    .orderBy(GuestListEntriesTable.id, SortOrder.ASC)
+                    .limit(size, offset)
+                    .map { it.toGuestListEntry() }
+            }
+        }
+    }
+
+    override suspend fun bulkImport(
+        listId: Long,
+        rows: List<ParsedGuest>,
+        dryRun: Boolean,
+    ): BulkImportResult {
+        return withTxRetry {
+            transaction(database) {
+                val rejected = mutableListOf<RejectedRow>()
+                val validRows = mutableListOf<EntryValidationOutcome.Valid>()
+                rows.forEach { row ->
+                    val outcome =
+                        validateEntryInput(
+                            name = row.name,
+                            phone = row.phone,
+                            guestsCount = row.guestsCount,
+                            notes = row.notes,
+                            status = GuestListEntryStatus.PLANNED,
+                        )
+                    when (outcome) {
+                        is EntryValidationOutcome.Invalid -> rejected += RejectedRow(row.lineNumber, outcome.reason)
+                        is EntryValidationOutcome.Valid -> validRows += outcome
+                    }
+                }
+                if (!dryRun && validRows.isNotEmpty()) {
+                    GuestListEntriesTable.batchInsert(validRows) { valid ->
+                        this[GuestListEntriesTable.guestListId] = listId
+                        this[GuestListEntriesTable.fullName] = valid.name
+                        this[GuestListEntriesTable.phone] = valid.phone
+                        this[GuestListEntriesTable.plusOnesAllowed] = valid.guestsCount - MIN_GUESTS_PER_ENTRY
+                        this[GuestListEntriesTable.plusOnesUsed] = DEFAULT_PLUS_ONES_USED
+                        this[GuestListEntriesTable.category] = DEFAULT_CATEGORY
+                        this[GuestListEntriesTable.comment] = valid.notes
+                        this[GuestListEntriesTable.status] = GuestListEntryStatus.PLANNED.name
+                        this[GuestListEntriesTable.checkedInAt] = null
+                        this[GuestListEntriesTable.checkedInBy] = null
+                    }
+                }
+                BulkImportResult(validRows.size, rejected.toList())
+            }
+        }
+    }
+
+    private fun ResultRow.toGuestList(): GuestList {
+        return GuestList(
+            id = this[GuestListsTable.id],
+            clubId = this[GuestListsTable.clubId],
+            eventId = this[GuestListsTable.eventId],
+            ownerType = GuestListOwnerType.valueOf(this[GuestListsTable.ownerType]),
+            ownerUserId = this[GuestListsTable.ownerUserId],
+            title = this[GuestListsTable.title],
+            capacity = this[GuestListsTable.capacity],
+            arrivalWindowStart = this[GuestListsTable.arrivalWindowStart]?.toInstant(),
+            arrivalWindowEnd = this[GuestListsTable.arrivalWindowEnd]?.toInstant(),
+            status = GuestListStatus.valueOf(this[GuestListsTable.status]),
+            createdAt = this[GuestListsTable.createdAt].toInstant(),
+        )
+    }
+
+    private fun ResultRow.toGuestListEntry(): GuestListEntry {
+        return GuestListEntry(
+            id = this[GuestListEntriesTable.id],
+            listId = this[GuestListEntriesTable.guestListId],
+            fullName = this[GuestListEntriesTable.fullName],
+            phone = this[GuestListEntriesTable.phone],
+            guestsCount = this[GuestListEntriesTable.plusOnesAllowed] + MIN_GUESTS_PER_ENTRY,
+            notes = this[GuestListEntriesTable.comment],
+            status = GuestListEntryStatus.valueOf(this[GuestListEntriesTable.status]),
+            checkedInAt = this[GuestListEntriesTable.checkedInAt]?.toInstant(),
+            checkedInBy = this[GuestListEntriesTable.checkedInBy],
+        )
+    }
+}

--- a/core-data/src/main/kotlin/com/example/bot/data/club/GuestListTables.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/club/GuestListTables.kt
@@ -1,0 +1,36 @@
+package com.example.bot.data.club
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+
+/** Tables backing guest list repositories. */
+object GuestListsTable : Table("guest_lists") {
+    val id = long("id").autoIncrement()
+    val clubId = long("club_id")
+    val eventId = long("event_id")
+    val ownerType = text("owner_type")
+    val ownerUserId = long("owner_user_id")
+    val title = text("title")
+    val capacity = integer("capacity")
+    val arrivalWindowStart = timestampWithTimeZone("arrival_window_start").nullable()
+    val arrivalWindowEnd = timestampWithTimeZone("arrival_window_end").nullable()
+    val status = text("status")
+    val createdAt = timestampWithTimeZone("created_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object GuestListEntriesTable : Table("guest_list_entries") {
+    val id = long("id").autoIncrement()
+    val guestListId = long("guest_list_id")
+    val fullName = text("full_name")
+    val tgUsername = text("tg_username").nullable()
+    val phone = text("phone_e164").nullable()
+    val plusOnesAllowed = integer("plus_ones_allowed")
+    val plusOnesUsed = integer("plus_ones_used")
+    val category = text("category")
+    val comment = text("comment").nullable()
+    val status = text("status")
+    val checkedInAt = timestampWithTimeZone("checked_in_at").nullable()
+    val checkedInBy = long("checked_in_by").nullable()
+    override val primaryKey = PrimaryKey(id)
+}

--- a/core-data/src/main/kotlin/com/example/bot/data/club/GuestListValidation.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/club/GuestListValidation.kt
@@ -1,0 +1,96 @@
+package com.example.bot.data.club
+
+import com.example.bot.club.GuestListEntryStatus
+
+internal const val MIN_GUESTS_PER_ENTRY: Int = 1
+internal const val MAX_ADDITIONAL_GUESTS: Int = 10
+internal const val MAX_GUESTS_PER_ENTRY: Int = MIN_GUESTS_PER_ENTRY + MAX_ADDITIONAL_GUESTS
+internal const val DEFAULT_CATEGORY: String = "REGULAR"
+internal const val DEFAULT_PLUS_ONES_USED: Int = 0
+private const val PHONE_ERROR_MESSAGE: String = "Phone must contain digits and optional leading +"
+
+private val SEPARATOR_CHARS = setOf(' ', '-', '(', ')', '.', '/', '\\')
+
+internal sealed interface EntryValidationOutcome {
+    data class Valid(
+        val name: String,
+        val phone: String?,
+        val guestsCount: Int,
+        val notes: String?,
+        val status: GuestListEntryStatus,
+    ) : EntryValidationOutcome
+
+    data class Invalid(val reason: String) : EntryValidationOutcome
+}
+
+internal data class PhoneNormalization(val normalized: String?, val provided: Boolean, val valid: Boolean)
+
+internal fun sanitizePhone(raw: String?): PhoneNormalization {
+    val trimmed = raw?.trim()
+    val provided = !trimmed.isNullOrEmpty()
+    if (!provided) {
+        return PhoneNormalization(null, provided = false, valid = true)
+    }
+    val builder = StringBuilder()
+    var plusSeen = false
+    var valid = true
+    for (ch in trimmed!!) {
+        if (!valid) break
+        when {
+            ch == '+' ->
+                if (plusSeen || builder.isNotEmpty()) {
+                    valid = false
+                } else {
+                    builder.append(ch)
+                    plusSeen = true
+                }
+            ch.isDigit() -> builder.append(ch)
+            ch in SEPARATOR_CHARS || ch.isWhitespace() -> Unit
+            else -> valid = false
+        }
+    }
+    val normalized = builder.toString()
+    val sanitizedValid = valid && normalized.isNotEmpty() && normalized != "+"
+    return if (sanitizedValid) {
+        PhoneNormalization(normalized, provided = true, valid = true)
+    } else {
+        PhoneNormalization(null, provided = true, valid = false)
+    }
+}
+
+internal fun validateEntryInput(
+    name: String,
+    phone: String?,
+    guestsCount: Int,
+    notes: String?,
+    status: GuestListEntryStatus,
+): EntryValidationOutcome {
+    val trimmedName = name.trim()
+    val phoneNormalization = sanitizePhone(phone)
+    val error =
+        when {
+            trimmedName.isEmpty() -> "Name must not be blank"
+            guestsCount < MIN_GUESTS_PER_ENTRY -> "guests_count must be >= $MIN_GUESTS_PER_ENTRY"
+            guestsCount > MAX_GUESTS_PER_ENTRY -> "guests_count must be <= $MAX_GUESTS_PER_ENTRY"
+            !phoneNormalization.valid && phoneNormalization.provided -> PHONE_ERROR_MESSAGE
+            else -> null
+        }
+    return if (error != null) {
+        EntryValidationOutcome.Invalid(error)
+    } else {
+        val normalizedNotes = notes?.trim()?.takeIf { it.isNotEmpty() }
+        val normalizedPhone =
+            if (phoneNormalization.provided && phoneNormalization.valid) {
+                phoneNormalization.normalized
+            } else {
+                null
+            }
+        EntryValidationOutcome.Valid(
+            name = trimmedName,
+            phone = normalizedPhone,
+            guestsCount = guestsCount,
+            notes = normalizedNotes,
+            status = status,
+        )
+    }
+}

--- a/core-data/src/main/kotlin/com/example/bot/data/club/TableRepositoryImpl.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/club/TableRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package com.example.bot.data.club
+
+import com.example.bot.club.Table
+import com.example.bot.club.TableRepository
+import com.example.bot.data.booking.TablesTable
+import com.example.bot.data.db.withTxRetry
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class TableRepositoryImpl(private val database: Database) : TableRepository {
+    override suspend fun listByClub(clubId: Long): List<Table> {
+        return withTxRetry {
+            transaction(database) {
+                TablesTable
+                    .select { TablesTable.clubId eq clubId }
+                    .orderBy(TablesTable.tableNumber, SortOrder.ASC)
+                    .map { it.toTable() }
+            }
+        }
+    }
+
+    override suspend fun get(id: Long): Table? {
+        return withTxRetry {
+            transaction(database) {
+                TablesTable
+                    .select { TablesTable.id eq id }
+                    .firstOrNull()
+                    ?.toTable()
+            }
+        }
+    }
+
+    private fun ResultRow.toTable(): Table {
+        return Table(
+            id = this[TablesTable.id],
+            clubId = this[TablesTable.clubId],
+            zoneId = this[TablesTable.zoneId],
+            number = this[TablesTable.tableNumber],
+            capacity = this[TablesTable.capacity],
+            minDeposit = this[TablesTable.minDeposit],
+            active = this[TablesTable.active],
+        )
+    }
+}

--- a/core-data/src/main/resources/db/migration/h2/V9__club_indexes.sql
+++ b/core-data/src/main/resources/db/migration/h2/V9__club_indexes.sql
@@ -1,0 +1,27 @@
+ALTER TABLE guest_lists
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE guest_list_entries ALTER COLUMN status SET DEFAULT 'PLANNED';
+ALTER TABLE guest_list_entries ALTER COLUMN status SET CHECK (status IN ('PLANNED','CHECKED_IN','NO_SHOW'));
+
+UPDATE guest_list_entries
+SET status =
+    CASE status
+        WHEN 'ARRIVED' THEN 'CHECKED_IN'
+        WHEN 'NO_SHOW' THEN 'NO_SHOW'
+        WHEN 'APPROVED' THEN 'PLANNED'
+        WHEN 'INVITED' THEN 'PLANNED'
+        WHEN 'DENIED' THEN 'NO_SHOW'
+        WHEN 'LATE' THEN 'NO_SHOW'
+        ELSE status
+    END;
+
+UPDATE guest_list_entries
+SET checked_in_at = NULL,
+    checked_in_by = NULL
+WHERE status <> 'CHECKED_IN';
+
+CREATE INDEX IF NOT EXISTS idx_guest_list_entries_list_status ON guest_list_entries(guest_list_id, status);
+CREATE INDEX IF NOT EXISTS idx_guest_lists_club_created_at ON guest_lists(club_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_events_club_start ON events(club_id, start_at);
+CREATE INDEX IF NOT EXISTS idx_tables_club ON tables(club_id);

--- a/core-data/src/main/resources/db/migration/postgresql/V9__club_indexes.sql
+++ b/core-data/src/main/resources/db/migration/postgresql/V9__club_indexes.sql
@@ -1,0 +1,34 @@
+-- Ensure guest list tables expose created_at and modern statuses
+ALTER TABLE guest_lists
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Align entry statuses with application enums
+ALTER TABLE guest_list_entries DROP CONSTRAINT IF EXISTS guest_list_entries_status_check;
+ALTER TABLE guest_list_entries ALTER COLUMN status TYPE TEXT;
+ALTER TABLE guest_list_entries ALTER COLUMN status SET DEFAULT 'PLANNED';
+
+UPDATE guest_list_entries
+SET status =
+    CASE status
+        WHEN 'ARRIVED' THEN 'CHECKED_IN'
+        WHEN 'NO_SHOW' THEN 'NO_SHOW'
+        WHEN 'APPROVED' THEN 'PLANNED'
+        WHEN 'INVITED' THEN 'PLANNED'
+        WHEN 'DENIED' THEN 'NO_SHOW'
+        WHEN 'LATE' THEN 'NO_SHOW'
+        ELSE status
+    END;
+
+UPDATE guest_list_entries
+SET checked_in_at = NULL,
+    checked_in_by = NULL
+WHERE status <> 'CHECKED_IN';
+
+ALTER TABLE guest_list_entries
+    ADD CONSTRAINT guest_list_entries_status_check CHECK (status IN ('PLANNED', 'CHECKED_IN', 'NO_SHOW'));
+
+-- Recreate helpful indexes
+CREATE INDEX IF NOT EXISTS idx_guest_list_entries_list_status ON guest_list_entries(guest_list_id, status);
+CREATE INDEX IF NOT EXISTS idx_guest_lists_club_created_at ON guest_lists(club_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_events_club_start ON events(club_id, start_at);
+CREATE INDEX IF NOT EXISTS idx_tables_club ON tables(club_id);

--- a/core-data/src/test/kotlin/com/example/bot/data/club/EventRepositoryIT.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/club/EventRepositoryIT.kt
@@ -1,0 +1,67 @@
+package com.example.bot.data.club
+
+import com.example.bot.club.Event
+import com.example.bot.club.EventRepository
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class EventRepositoryIT : PostgresClubIntegrationTest() {
+    private lateinit var repository: EventRepository
+
+    @BeforeEach
+    fun initRepository() {
+        repository = EventRepositoryImpl(database)
+    }
+
+    @Test
+    fun `list events by club and date range`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val otherClubId = insertClub(name = "Nebula", timezone = "Europe/Berlin")
+        val insideRangeStart = Instant.parse("2024-03-01T18:00:00Z")
+        val insideRangeEnd = Instant.parse("2024-03-02T02:00:00Z")
+        val outsideRangeStart = Instant.parse("2024-02-01T18:00:00Z")
+        val outsideRangeEnd = Instant.parse("2024-02-02T02:00:00Z")
+        val otherClubStart = Instant.parse("2024-03-01T20:00:00Z")
+        val otherClubEnd = Instant.parse("2024-03-02T03:00:00Z")
+
+        val inRangeEventId = insertEvent(clubId, "Spring Night", insideRangeStart, insideRangeEnd)
+        insertEvent(clubId, "Old Night", outsideRangeStart, outsideRangeEnd)
+        insertEvent(otherClubId, "Berlin Night", otherClubStart, otherClubEnd)
+
+        val events = repository.listByClub(clubId, insideRangeStart..insideRangeEnd)
+
+        val expected = listOf(
+            Event(
+                id = inRangeEventId,
+                clubId = clubId,
+                title = "Spring Night",
+                startAt = insideRangeStart,
+                endAt = insideRangeEnd,
+                isSpecial = false,
+                posterUrl = null,
+            ),
+        )
+        assertEquals(expected, events)
+    }
+
+    @Test
+    fun `load event by id`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val startAt = Instant.parse("2024-04-05T18:00:00Z")
+        val endAt = Instant.parse("2024-04-06T02:00:00Z")
+        val eventId = insertEvent(clubId, "Anniversary", startAt, endAt)
+
+        val event = repository.get(eventId)
+        assertNotNull(event)
+        assertEquals(eventId, event!!.id)
+        assertEquals("Anniversary", event.title)
+
+        val missing = repository.get(eventId + 10)
+        assertNull(missing)
+    }
+}

--- a/core-data/src/test/kotlin/com/example/bot/data/club/GuestListRepositoryIT.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/club/GuestListRepositoryIT.kt
@@ -1,0 +1,241 @@
+package com.example.bot.data.club
+
+import com.example.bot.club.GuestListEntryStatus
+import com.example.bot.club.GuestListOwnerType
+import com.example.bot.club.GuestListRepository
+import com.example.bot.club.GuestListStatus
+import com.example.bot.club.ParsedGuest
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GuestListRepositoryIT : PostgresClubIntegrationTest() {
+    private val fixedClock: Clock = Clock.fixed(Instant.parse("2024-05-01T10:15:30Z"), ZoneOffset.UTC)
+    private lateinit var repository: GuestListRepository
+
+    @BeforeEach
+    fun initRepository() {
+        repository = GuestListRepositoryImpl(database, fixedClock)
+    }
+
+    @Test
+    fun `create guest list and manage entries`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val eventId = insertEvent(
+            clubId = clubId,
+            title = "Opening Night",
+            startAt = Instant.parse("2024-05-10T18:00:00Z"),
+            endAt = Instant.parse("2024-05-11T02:00:00Z"),
+        )
+        val ownerId = insertUser(username = "manager", displayName = "Manager One")
+
+        val created =
+            repository.createList(
+                clubId = clubId,
+                eventId = eventId,
+                ownerType = GuestListOwnerType.MANAGER,
+                ownerUserId = ownerId,
+                title = "VIP",
+                capacity = 50,
+                arrivalWindowStart = Instant.parse("2024-05-10T17:30:00Z"),
+                arrivalWindowEnd = Instant.parse("2024-05-10T19:00:00Z"),
+                status = GuestListStatus.ACTIVE,
+            )
+        assertEquals("VIP", created.title)
+
+        val fetched = repository.getList(created.id)
+        assertEquals(created, fetched)
+
+        val lists = repository.listListsByClub(clubId, page = 0, size = 10)
+        assertEquals(listOf(created), lists)
+
+        val entry =
+            repository.addEntry(
+                listId = created.id,
+                fullName = "John Doe",
+                phone = "+1 234 567 890",
+                guestsCount = 3,
+                notes = "all access",
+                status = GuestListEntryStatus.PLANNED,
+            )
+        assertEquals(3, entry.guestsCount)
+
+        val updated = repository.setEntryStatus(entry.id, GuestListEntryStatus.CHECKED_IN, checkedInBy = ownerId)
+        assertNotNull(updated)
+        assertEquals(GuestListEntryStatus.CHECKED_IN, updated!!.status)
+        assertEquals(fixedClock.instant(), updated.checkedInAt)
+
+        val entries = repository.listEntries(created.id, page = 0, size = 10)
+        assertEquals(listOf(updated), entries)
+    }
+
+    @Test
+    fun `bulk import inserts valid rows`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val eventId = insertEvent(
+            clubId = clubId,
+            title = "Showcase",
+            startAt = Instant.parse("2024-05-20T18:00:00Z"),
+            endAt = Instant.parse("2024-05-21T02:00:00Z"),
+        )
+        val ownerId = insertUser(username = "host", displayName = "Host")
+        val list =
+            repository.createList(
+                clubId = clubId,
+                eventId = eventId,
+                ownerType = GuestListOwnerType.ADMIN,
+                ownerUserId = ownerId,
+                title = "Press",
+                capacity = 40,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        val rows =
+            listOf(
+                ParsedGuest(lineNumber = 2, name = "Alice Smith", phone = "+1 (234) 555-0000", guestsCount = 2, notes = "VIP"),
+                ParsedGuest(lineNumber = 3, name = "Bob Stone", phone = "1234567", guestsCount = 1, notes = null),
+            )
+
+        val result = repository.bulkImport(list.id, rows, dryRun = false)
+
+        assertEquals(2, result.acceptedCount)
+        assertTrue(result.rejected.isEmpty())
+
+        val entries = repository.listEntries(list.id, page = 0, size = 10)
+        assertEquals(2, entries.size)
+        val first = entries[0]
+        assertEquals("Alice Smith", first.fullName)
+        assertEquals("+12345550000", first.phone)
+        assertEquals(2, first.guestsCount)
+    }
+
+    @Test
+    fun `bulk import rejects invalid data`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val eventId = insertEvent(
+            clubId = clubId,
+            title = "Club Night",
+            startAt = Instant.parse("2024-06-01T18:00:00Z"),
+            endAt = Instant.parse("2024-06-02T02:00:00Z"),
+        )
+        val ownerId = insertUser(username = "crew", displayName = "Crew")
+        val list =
+            repository.createList(
+                clubId = clubId,
+                eventId = eventId,
+                ownerType = GuestListOwnerType.MANAGER,
+                ownerUserId = ownerId,
+                title = "Friends",
+                capacity = 30,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        val rows =
+            listOf(
+                ParsedGuest(lineNumber = 2, name = "Charlie", phone = "invalid", guestsCount = 2, notes = null),
+                ParsedGuest(lineNumber = 3, name = "Diana", phone = "", guestsCount = -1, notes = null),
+                ParsedGuest(lineNumber = 4, name = "Eve", phone = null, guestsCount = 4, notes = "+1"),
+            )
+
+        val result = repository.bulkImport(list.id, rows, dryRun = false)
+
+        assertEquals(1, result.acceptedCount)
+        assertEquals(2, result.rejected.size)
+        val reasons = result.rejected.associate { it.line to it.reason }
+        assertEquals("Phone must contain digits and optional leading +", reasons[2])
+        assertEquals("guests_count must be >= 1", reasons[3])
+
+        val entries = repository.listEntries(list.id, page = 0, size = 10)
+        assertEquals(1, entries.size)
+        assertEquals("Eve", entries.single().fullName)
+        assertEquals(4, entries.single().guestsCount)
+    }
+
+    @Test
+    fun `bulk import dry run does not persist`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val eventId = insertEvent(
+            clubId = clubId,
+            title = "Preview",
+            startAt = Instant.parse("2024-06-10T18:00:00Z"),
+            endAt = Instant.parse("2024-06-11T02:00:00Z"),
+        )
+        val ownerId = insertUser(username = "dry", displayName = "Dry Run")
+        val list =
+            repository.createList(
+                clubId = clubId,
+                eventId = eventId,
+                ownerType = GuestListOwnerType.ADMIN,
+                ownerUserId = ownerId,
+                title = "Guests",
+                capacity = 20,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        val rows =
+            listOf(
+                ParsedGuest(lineNumber = 2, name = "Frank", phone = "+7 999 111 22 33", guestsCount = 2, notes = null),
+            )
+
+        val result = repository.bulkImport(list.id, rows, dryRun = true)
+
+        assertEquals(1, result.acceptedCount)
+        assertTrue(result.rejected.isEmpty())
+        val entries = repository.listEntries(list.id, page = 0, size = 10)
+        assertTrue(entries.isEmpty())
+    }
+
+    @Test
+    fun `list entries pagination and status filter`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val eventId = insertEvent(
+            clubId = clubId,
+            title = "Festival",
+            startAt = Instant.parse("2024-06-15T18:00:00Z"),
+            endAt = Instant.parse("2024-06-16T02:00:00Z"),
+        )
+        val ownerId = insertUser(username = "organizer", displayName = "Organizer")
+        val list =
+            repository.createList(
+                clubId = clubId,
+                eventId = eventId,
+                ownerType = GuestListOwnerType.ADMIN,
+                ownerUserId = ownerId,
+                title = "Line", capacity = 100,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        val first = repository.addEntry(list.id, "Guest A", null, guestsCount = 1, notes = null)
+        val second = repository.addEntry(list.id, "Guest B", null, guestsCount = 2, notes = null)
+        repository.setEntryStatus(second.id, GuestListEntryStatus.CHECKED_IN, checkedInBy = ownerId)
+        val third = repository.addEntry(list.id, "Guest C", null, guestsCount = 3, notes = null)
+        repository.setEntryStatus(third.id, GuestListEntryStatus.NO_SHOW)
+
+        val pageOne = repository.listEntries(list.id, page = 0, size = 2)
+        assertEquals(listOf("Guest A", "Guest B"), pageOne.map { it.fullName })
+        assertEquals(
+            listOf(GuestListEntryStatus.PLANNED, GuestListEntryStatus.CHECKED_IN),
+            pageOne.map { it.status },
+        )
+        assertEquals(listOf(null, fixedClock.instant()), pageOne.map { it.checkedInAt })
+        assertEquals(listOf(null, ownerId), pageOne.map { it.checkedInBy })
+
+        val pageTwo = repository.listEntries(list.id, page = 1, size = 2)
+        assertEquals(1, pageTwo.size)
+        assertEquals("Guest C", pageTwo.single().fullName)
+        assertEquals(GuestListEntryStatus.NO_SHOW, pageTwo.single().status)
+
+        val checkedIn = repository.listEntries(list.id, page = 0, size = 10, statusFilter = GuestListEntryStatus.CHECKED_IN)
+        assertEquals(listOf(pageOne[1]), checkedIn)
+    }
+}

--- a/core-data/src/test/kotlin/com/example/bot/data/club/PostgresClubIntegrationTest.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/club/PostgresClubIntegrationTest.kt
@@ -1,0 +1,166 @@
+package com.example.bot.data.club
+
+import com.example.bot.data.booking.EventsTable
+import com.example.bot.data.booking.TablesTable
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.ZoneOffset
+import org.flywaydb.core.Flyway
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import testing.RequiresDocker
+
+@RequiresDocker
+@Tag("it")
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class PostgresClubIntegrationTest {
+    protected lateinit var database: Database
+
+    @BeforeAll
+    fun startContainer() {
+        postgres.start()
+        Flyway
+            .configure()
+            .dataSource(postgres.jdbcUrl, postgres.username, postgres.password)
+            .locations(
+                "classpath:db/migration/common",
+                "classpath:db/migration/postgresql",
+            )
+            .baselineOnMigrate(true)
+            .load()
+            .migrate()
+        database =
+            Database.connect(
+                url = postgres.jdbcUrl,
+                driver = postgres.driverClassName,
+                user = postgres.username,
+                password = postgres.password,
+            )
+    }
+
+    @BeforeEach
+    fun cleanDatabase() {
+        transaction(database) {
+            exec(
+                "TRUNCATE TABLE guest_list_entries, guest_lists, bookings, booking_holds, events, tables, zones, clubs, users RESTART IDENTITY CASCADE",
+            )
+        }
+    }
+
+    protected fun insertClub(name: String, timezone: String = "Europe/Moscow"): Long {
+        return transaction(database) {
+            ClubsTable
+                .insert {
+                    it[ClubsTable.name] = name
+                    it[ClubsTable.description] = null
+                    it[ClubsTable.timezone] = timezone
+                    it[ClubsTable.adminChannelId] = null
+                    it[ClubsTable.bookingsTopicId] = null
+                    it[ClubsTable.checkinTopicId] = null
+                    it[ClubsTable.qaTopicId] = null
+                }
+                .resultedValues!!
+                .single()[ClubsTable.id]
+        }
+    }
+
+    protected fun insertEvent(
+        clubId: Long,
+        title: String,
+        startAt: Instant,
+        endAt: Instant,
+    ): Long {
+        return transaction(database) {
+            EventsTable
+                .insert {
+                    it[EventsTable.clubId] = clubId
+                    it[EventsTable.title] = title
+                    it[EventsTable.startAt] = startAt.atOffset(ZoneOffset.UTC)
+                    it[EventsTable.endAt] = endAt.atOffset(ZoneOffset.UTC)
+                    it[EventsTable.isSpecial] = false
+                    it[EventsTable.posterUrl] = null
+                }
+                .resultedValues!!
+                .single()[EventsTable.id]
+        }
+    }
+
+    protected fun insertTable(
+        clubId: Long,
+        tableNumber: Int,
+        capacity: Int,
+        minDeposit: BigDecimal,
+        active: Boolean = true,
+    ): Long {
+        return transaction(database) {
+            TablesTable
+                .insert {
+                    it[TablesTable.clubId] = clubId
+                    it[TablesTable.zoneId] = null
+                    it[TablesTable.tableNumber] = tableNumber
+                    it[TablesTable.capacity] = capacity
+                    it[TablesTable.minDeposit] = minDeposit
+                    it[TablesTable.active] = active
+                }
+                .resultedValues!!
+                .single()[TablesTable.id]
+        }
+    }
+
+    protected fun insertUser(username: String, displayName: String): Long {
+        return transaction(database) {
+            UsersTable
+                .insert {
+                    it[UsersTable.telegramUserId] = null
+                    it[UsersTable.username] = username
+                    it[UsersTable.displayName] = displayName
+                    it[UsersTable.phoneE164] = null
+                }
+                .resultedValues!!
+                .single()[UsersTable.id]
+        }
+    }
+
+    @AfterAll
+    fun stopContainer() {
+        postgres.stop()
+    }
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+    }
+}
+
+private object ClubsTable : Table("clubs") {
+    val id = long("id").autoIncrement()
+    val name = text("name")
+    val description = text("description").nullable()
+    val timezone = text("timezone")
+    val adminChannelId = long("admin_channel_id").nullable()
+    val bookingsTopicId = integer("bookings_topic_id").nullable()
+    val checkinTopicId = integer("checkin_topic_id").nullable()
+    val qaTopicId = integer("qa_topic_id").nullable()
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object UsersTable : Table("users") {
+    val id = long("id").autoIncrement()
+    val telegramUserId = long("telegram_user_id").nullable()
+    val username = text("username").nullable()
+    val displayName = text("display_name").nullable()
+    val phoneE164 = text("phone_e164").nullable()
+    override val primaryKey = PrimaryKey(id)
+}

--- a/core-data/src/test/kotlin/com/example/bot/data/club/TableRepositoryIT.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/club/TableRepositoryIT.kt
@@ -1,0 +1,67 @@
+package com.example.bot.data.club
+
+import com.example.bot.club.Table
+import com.example.bot.club.TableRepository
+import java.math.BigDecimal
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TableRepositoryIT : PostgresClubIntegrationTest() {
+    private lateinit var repository: TableRepository
+
+    @BeforeEach
+    fun initRepository() {
+        repository = TableRepositoryImpl(database)
+    }
+
+    @Test
+    fun `list tables by club`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val otherClubId = insertClub(name = "Nebula")
+        val firstTableId = insertTable(clubId, tableNumber = 1, capacity = 4, minDeposit = BigDecimal("100.00"))
+        val secondTableId = insertTable(clubId, tableNumber = 2, capacity = 6, minDeposit = BigDecimal("150.00"))
+        insertTable(otherClubId, tableNumber = 1, capacity = 2, minDeposit = BigDecimal("80.00"))
+
+        val tables = repository.listByClub(clubId)
+
+        val expected = listOf(
+            Table(
+                id = firstTableId,
+                clubId = clubId,
+                zoneId = null,
+                number = 1,
+                capacity = 4,
+                minDeposit = BigDecimal("100.00"),
+                active = true,
+            ),
+            Table(
+                id = secondTableId,
+                clubId = clubId,
+                zoneId = null,
+                number = 2,
+                capacity = 6,
+                minDeposit = BigDecimal("150.00"),
+                active = true,
+            ),
+        )
+        assertEquals(expected, tables)
+    }
+
+    @Test
+    fun `get table by id`() = runBlocking {
+        val clubId = insertClub(name = "Aurora")
+        val tableId = insertTable(clubId, tableNumber = 5, capacity = 8, minDeposit = BigDecimal("250.00"), active = false)
+
+        val table = repository.get(tableId)
+        assertNotNull(table)
+        assertEquals(tableId, table!!.id)
+        assertEquals(false, table.active)
+
+        val missing = repository.get(tableId + 42)
+        assertNull(missing)
+    }
+}

--- a/core-domain/src/main/kotlin/com/example/bot/club/EventRepository.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/club/EventRepository.kt
@@ -1,0 +1,30 @@
+package com.example.bot.club
+
+import java.time.Instant
+import kotlin.ranges.ClosedRange
+
+/**
+ * Repository exposing club events for read models.
+ */
+interface EventRepository {
+    /**
+     * Lists events for the given [clubId] that start within [dateRange].
+     */
+    suspend fun listByClub(clubId: Long, dateRange: ClosedRange<Instant>): List<Event>
+
+    /**
+     * Loads an event by its identifier.
+     */
+    suspend fun get(id: Long): Event?
+}
+
+/** Simple event projection used by the data layer. */
+data class Event(
+    val id: Long,
+    val clubId: Long,
+    val title: String?,
+    val startAt: Instant,
+    val endAt: Instant,
+    val isSpecial: Boolean,
+    val posterUrl: String?,
+)

--- a/core-domain/src/main/kotlin/com/example/bot/club/GuestListRepository.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/club/GuestListRepository.kt
@@ -1,0 +1,105 @@
+package com.example.bot.club
+
+import java.time.Instant
+
+/**
+ * Repository managing guest lists and their entries.
+ */
+interface GuestListRepository {
+    @Suppress("LongParameterList")
+    suspend fun createList(
+        clubId: Long,
+        eventId: Long,
+        ownerType: GuestListOwnerType,
+        ownerUserId: Long,
+        title: String,
+        capacity: Int,
+        arrivalWindowStart: Instant?,
+        arrivalWindowEnd: Instant?,
+        status: GuestListStatus = GuestListStatus.ACTIVE,
+    ): GuestList
+
+    suspend fun getList(id: Long): GuestList?
+
+    suspend fun listListsByClub(clubId: Long, page: Int, size: Int): List<GuestList>
+
+    suspend fun addEntry(
+        listId: Long,
+        fullName: String,
+        phone: String?,
+        guestsCount: Int,
+        notes: String?,
+        status: GuestListEntryStatus = GuestListEntryStatus.PLANNED,
+    ): GuestListEntry
+
+    suspend fun setEntryStatus(
+        entryId: Long,
+        status: GuestListEntryStatus,
+        checkedInBy: Long? = null,
+        at: Instant? = null,
+    ): GuestListEntry?
+
+    suspend fun listEntries(
+        listId: Long,
+        page: Int,
+        size: Int,
+        statusFilter: GuestListEntryStatus? = null,
+    ): List<GuestListEntry>
+
+    suspend fun bulkImport(listId: Long, rows: List<ParsedGuest>, dryRun: Boolean): BulkImportResult
+}
+
+enum class GuestListOwnerType {
+    PROMOTER,
+    ADMIN,
+    MANAGER,
+}
+
+enum class GuestListStatus {
+    ACTIVE,
+    CLOSED,
+}
+
+enum class GuestListEntryStatus {
+    PLANNED,
+    CHECKED_IN,
+    NO_SHOW,
+}
+
+data class GuestList(
+    val id: Long,
+    val clubId: Long,
+    val eventId: Long,
+    val ownerType: GuestListOwnerType,
+    val ownerUserId: Long,
+    val title: String,
+    val capacity: Int,
+    val arrivalWindowStart: Instant?,
+    val arrivalWindowEnd: Instant?,
+    val status: GuestListStatus,
+    val createdAt: Instant,
+)
+
+data class GuestListEntry(
+    val id: Long,
+    val listId: Long,
+    val fullName: String,
+    val phone: String?,
+    val guestsCount: Int,
+    val notes: String?,
+    val status: GuestListEntryStatus,
+    val checkedInAt: Instant?,
+    val checkedInBy: Long?,
+)
+
+data class ParsedGuest(
+    val lineNumber: Int,
+    val name: String,
+    val phone: String?,
+    val guestsCount: Int,
+    val notes: String?,
+)
+
+data class RejectedRow(val line: Int, val reason: String)
+
+data class BulkImportResult(val acceptedCount: Int, val rejected: List<RejectedRow>)

--- a/core-domain/src/main/kotlin/com/example/bot/club/TableRepository.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/club/TableRepository.kt
@@ -1,0 +1,25 @@
+package com.example.bot.club
+
+import java.math.BigDecimal
+
+/**
+ * Repository exposing club tables for read models.
+ */
+interface TableRepository {
+    /** Lists tables belonging to [clubId]. */
+    suspend fun listByClub(clubId: Long): List<Table>
+
+    /** Loads a table by its identifier. */
+    suspend fun get(id: Long): Table?
+}
+
+/** Representation of a club table. */
+data class Table(
+    val id: Long,
+    val clubId: Long,
+    val zoneId: Long?,
+    val number: Int,
+    val capacity: Int,
+    val minDeposit: BigDecimal,
+    val active: Boolean,
+)


### PR DESCRIPTION
## Summary
- add domain models and repository interfaces for events, tables, and guest lists with bulk import support
- implement Exposed-based repositories and guest list CSV/TSV parsing plus schema indexes for club data
- cover repositories with PostgreSQL Testcontainers integration tests including bulk import scenarios

## Testing
- ./gradlew clean build test detekt --console=plain
- ./gradlew clean build test detekt -PrunIT=true --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cde8595ad48321a978fe2b7b57ef98