### PR TITLE
Add promo schema and repositories

### DIFF
--- a/core-data/src/main/kotlin/com/example/bot/data/promo/PromoRepositories.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/promo/PromoRepositories.kt
@@ -1,0 +1,394 @@
+package com.example.bot.data.promo
+
+import com.example.bot.data.db.isUniqueViolation
+import com.example.bot.data.db.withTxRetry
+import com.example.bot.promo.BookingTemplate
+import com.example.bot.promo.BookingTemplateError
+import com.example.bot.promo.BookingTemplateRepository
+import com.example.bot.promo.BookingTemplateResult
+import com.example.bot.promo.BookingTemplateSignature
+import com.example.bot.promo.PromoAttribution
+import com.example.bot.promo.PromoAttributionError
+import com.example.bot.promo.PromoAttributionRepository
+import com.example.bot.promo.PromoAttributionResult
+import com.example.bot.promo.PromoLink
+import com.example.bot.promo.PromoLinkError
+import com.example.bot.promo.PromoLinkRepository
+import com.example.bot.promo.PromoLinkResult
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.HexFormat
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.CurrentTimestamp
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.Table
+
+private object PromoLinksTable : Table("promo_links") {
+    val id = long("id").autoIncrement()
+    val promoterUserId = long("promoter_user_id")
+    val clubId = long("club_id").nullable()
+    val utmSource = text("utm_source")
+    val utmMedium = text("utm_medium")
+    val utmCampaign = text("utm_campaign")
+    val utmContent = text("utm_content").nullable()
+    val createdAt = timestampWithTimeZone("created_at").defaultExpression(CurrentTimestamp())
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object PromoAttributionTable : Table("promo_attribution") {
+    val id = long("id").autoIncrement()
+    val bookingId = uuid("booking_id")
+    val promoLinkId = long("promo_link_id")
+    val promoterUserId = long("promoter_user_id")
+    val utmSource = text("utm_source")
+    val utmMedium = text("utm_medium")
+    val utmCampaign = text("utm_campaign")
+    val utmContent = text("utm_content").nullable()
+    val createdAt = timestampWithTimeZone("created_at").defaultExpression(CurrentTimestamp())
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object BookingTemplatesTable : Table("booking_templates") {
+    val id = long("id").autoIncrement()
+    val promoterUserId = long("promoter_user_id")
+    val clubId = long("club_id")
+    val tableCapacityMin = integer("table_capacity_min")
+    val notes = text("notes").nullable()
+    val isActive = bool("is_active")
+    val createdAt = timestampWithTimeZone("created_at").defaultExpression(CurrentTimestamp())
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+private val hexFormat: HexFormat = HexFormat.of()
+
+class PromoLinkRepositoryImpl(
+    private val db: Database,
+    private val clock: Clock = Clock.systemUTC(),
+) : PromoLinkRepository {
+    override suspend fun issueLink(
+        promoterUserId: Long,
+        clubId: Long?,
+        utmSource: String,
+        utmMedium: String,
+        utmCampaign: String,
+        utmContent: String?,
+    ): PromoLink {
+        val now = Instant.now(clock)
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                PromoLinksTable
+                    .insert {
+                        it[PromoLinksTable.promoterUserId] = promoterUserId
+                        it[PromoLinksTable.clubId] = clubId
+                        it[PromoLinksTable.utmSource] = utmSource
+                        it[PromoLinksTable.utmMedium] = utmMedium
+                        it[PromoLinksTable.utmCampaign] = utmCampaign
+                        it[PromoLinksTable.utmContent] = utmContent
+                        it[PromoLinksTable.createdAt] = now.atOffset(ZoneOffset.UTC)
+                    }
+                    .resultedValues
+                    ?.single()
+                    ?.toPromoLink()
+                    ?: error("Failed to insert promo link")
+            }
+        }
+    }
+
+    override suspend fun get(id: Long): PromoLink? {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                PromoLinksTable
+                    .select { PromoLinksTable.id eq id }
+                    .limit(1)
+                    .firstOrNull()
+                    ?.toPromoLink()
+            }
+        }
+    }
+
+    override suspend fun listByPromoter(promoterUserId: Long, clubId: Long?): List<PromoLink> {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                val query =
+                    PromoLinksTable
+                        .select { PromoLinksTable.promoterUserId eq promoterUserId }
+                clubId?.let { desiredClub -> query.andWhere { PromoLinksTable.clubId eq desiredClub } }
+                query
+                    .orderBy(PromoLinksTable.createdAt, SortOrder.DESC)
+                    .map { it.toPromoLink() }
+            }
+        }
+    }
+
+    override suspend fun deactivate(id: Long): PromoLinkResult<Unit> {
+        val affected =
+            withTxRetry {
+                newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                    PromoLinksTable.deleteWhere { PromoLinksTable.id eq id }
+                }
+            }
+        return if (affected == 0) {
+            PromoLinkResult.Failure(PromoLinkError.NotFound)
+        } else {
+            PromoLinkResult.Success(Unit)
+        }
+    }
+}
+
+class PromoAttributionRepositoryImpl(
+    private val db: Database,
+    private val clock: Clock = Clock.systemUTC(),
+) : PromoAttributionRepository {
+    override suspend fun attachUnique(
+        bookingId: UUID,
+        promoLinkId: Long,
+        promoterUserId: Long,
+        utmSource: String,
+        utmMedium: String,
+        utmCampaign: String,
+        utmContent: String?,
+    ): PromoAttributionResult<PromoAttribution> {
+        val now = Instant.now(clock)
+        return try {
+            val inserted =
+                withTxRetry {
+                    newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                        PromoAttributionTable
+                            .insert {
+                                it[PromoAttributionTable.bookingId] = bookingId
+                                it[PromoAttributionTable.promoLinkId] = promoLinkId
+                                it[PromoAttributionTable.promoterUserId] = promoterUserId
+                                it[PromoAttributionTable.utmSource] = utmSource
+                                it[PromoAttributionTable.utmMedium] = utmMedium
+                                it[PromoAttributionTable.utmCampaign] = utmCampaign
+                                it[PromoAttributionTable.utmContent] = utmContent
+                                it[PromoAttributionTable.createdAt] = now.atOffset(ZoneOffset.UTC)
+                            }
+                            .resultedValues
+                            ?.single()
+                            ?.toPromoAttribution()
+                            ?: error("Failed to insert promo attribution")
+                    }
+                }
+            PromoAttributionResult.Success(inserted)
+        } catch (ex: Throwable) {
+            if (ex.isUniqueViolation()) {
+                PromoAttributionResult.Failure(PromoAttributionError.AlreadyAttributed)
+            } else {
+                throw ex
+            }
+        }
+    }
+
+    override suspend fun findByBooking(bookingId: UUID): PromoAttribution? {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                PromoAttributionTable
+                    .select { PromoAttributionTable.bookingId eq bookingId }
+                    .limit(1)
+                    .firstOrNull()
+                    ?.toPromoAttribution()
+            }
+        }
+    }
+}
+
+class BookingTemplateRepositoryImpl(
+    private val db: Database,
+    private val clock: Clock = Clock.systemUTC(),
+) : BookingTemplateRepository {
+    override suspend fun create(
+        promoterUserId: Long,
+        clubId: Long,
+        tableCapacityMin: Int,
+        notes: String?,
+    ): BookingTemplate {
+        val now = Instant.now(clock)
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                BookingTemplatesTable
+                    .insert {
+                        it[BookingTemplatesTable.promoterUserId] = promoterUserId
+                        it[BookingTemplatesTable.clubId] = clubId
+                        it[BookingTemplatesTable.tableCapacityMin] = tableCapacityMin
+                        it[BookingTemplatesTable.notes] = notes
+                        it[BookingTemplatesTable.isActive] = true
+                        it[BookingTemplatesTable.createdAt] = now.atOffset(ZoneOffset.UTC)
+                    }
+                    .resultedValues
+                    ?.single()
+                    ?.toBookingTemplate()
+                    ?: error("Failed to insert booking template")
+            }
+        }
+    }
+
+    override suspend fun update(
+        id: Long,
+        tableCapacityMin: Int,
+        notes: String?,
+        isActive: Boolean,
+    ): BookingTemplateResult<BookingTemplate> {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                val updated =
+                    BookingTemplatesTable.update({ BookingTemplatesTable.id eq id }) {
+                        it[BookingTemplatesTable.tableCapacityMin] = tableCapacityMin
+                        it[BookingTemplatesTable.notes] = notes
+                        it[BookingTemplatesTable.isActive] = isActive
+                    }
+                if (updated == 0) {
+                    BookingTemplateResult.Failure(BookingTemplateError.NotFound)
+                } else {
+                    val row =
+                        BookingTemplatesTable
+                            .select { BookingTemplatesTable.id eq id }
+                            .limit(1)
+                            .first()
+                    BookingTemplateResult.Success(row.toBookingTemplate())
+                }
+            }
+        }
+    }
+
+    override suspend fun deactivate(id: Long): BookingTemplateResult<Unit> {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                val updated =
+                    BookingTemplatesTable.update({ BookingTemplatesTable.id eq id }) {
+                        it[BookingTemplatesTable.isActive] = false
+                    }
+                if (updated == 0) {
+                    BookingTemplateResult.Failure(BookingTemplateError.NotFound)
+                } else {
+                    BookingTemplateResult.Success(Unit)
+                }
+            }
+        }
+    }
+
+    override suspend fun get(id: Long): BookingTemplate? {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                BookingTemplatesTable
+                    .select { BookingTemplatesTable.id eq id }
+                    .limit(1)
+                    .firstOrNull()
+                    ?.toBookingTemplate()
+            }
+        }
+    }
+
+    override suspend fun listByOwner(promoterUserId: Long): List<BookingTemplate> {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                BookingTemplatesTable
+                    .select { BookingTemplatesTable.promoterUserId eq promoterUserId }
+                    .orderBy(BookingTemplatesTable.createdAt, SortOrder.DESC)
+                    .map { it.toBookingTemplate() }
+            }
+        }
+    }
+
+    override suspend fun listByClub(clubId: Long, onlyActive: Boolean): List<BookingTemplate> {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                val query =
+                    BookingTemplatesTable
+                        .select { BookingTemplatesTable.clubId eq clubId }
+                if (onlyActive) {
+                    query.andWhere { BookingTemplatesTable.isActive eq true }
+                }
+                query
+                    .orderBy(BookingTemplatesTable.createdAt, SortOrder.DESC)
+                    .map { it.toBookingTemplate() }
+            }
+        }
+    }
+
+    override suspend fun applyTemplateSignature(id: Long): BookingTemplateResult<BookingTemplateSignature> {
+        return withTxRetry {
+            newSuspendedTransaction(context = Dispatchers.IO, db = db) {
+                val row =
+                    BookingTemplatesTable
+                        .select { BookingTemplatesTable.id eq id }
+                        .limit(1)
+                        .firstOrNull()
+                        ?: return@newSuspendedTransaction BookingTemplateResult.Failure(BookingTemplateError.NotFound)
+                val template = row.toBookingTemplate()
+                val payload =
+                    buildString {
+                        append(template.promoterUserId)
+                        append('|')
+                        append(template.clubId)
+                        append('|')
+                        append(template.tableCapacityMin)
+                        append('|')
+                        append(template.notes ?: "")
+                        append('|')
+                        append(template.isActive)
+                    }
+                val digest = MessageDigest.getInstance("SHA-256")
+                val hash = digest.digest(payload.toByteArray(StandardCharsets.UTF_8))
+                val signature = hexFormat.formatHex(hash)
+                BookingTemplateResult.Success(BookingTemplateSignature(template.id, signature))
+            }
+        }
+    }
+}
+
+private fun ResultRow.toPromoLink(): PromoLink {
+    return PromoLink(
+        id = this[PromoLinksTable.id],
+        promoterUserId = this[PromoLinksTable.promoterUserId],
+        clubId = this[PromoLinksTable.clubId],
+        utmSource = this[PromoLinksTable.utmSource],
+        utmMedium = this[PromoLinksTable.utmMedium],
+        utmCampaign = this[PromoLinksTable.utmCampaign],
+        utmContent = this[PromoLinksTable.utmContent],
+        createdAt = this[PromoLinksTable.createdAt].toInstant(),
+    )
+}
+
+private fun ResultRow.toPromoAttribution(): PromoAttribution {
+    return PromoAttribution(
+        id = this[PromoAttributionTable.id],
+        bookingId = this[PromoAttributionTable.bookingId],
+        promoLinkId = this[PromoAttributionTable.promoLinkId],
+        promoterUserId = this[PromoAttributionTable.promoterUserId],
+        utmSource = this[PromoAttributionTable.utmSource],
+        utmMedium = this[PromoAttributionTable.utmMedium],
+        utmCampaign = this[PromoAttributionTable.utmCampaign],
+        utmContent = this[PromoAttributionTable.utmContent],
+        createdAt = this[PromoAttributionTable.createdAt].toInstant(),
+    )
+}
+
+private fun ResultRow.toBookingTemplate(): BookingTemplate {
+    return BookingTemplate(
+        id = this[BookingTemplatesTable.id],
+        promoterUserId = this[BookingTemplatesTable.promoterUserId],
+        clubId = this[BookingTemplatesTable.clubId],
+        tableCapacityMin = this[BookingTemplatesTable.tableCapacityMin],
+        notes = this[BookingTemplatesTable.notes],
+        isActive = this[BookingTemplatesTable.isActive],
+        createdAt = this[BookingTemplatesTable.createdAt].toInstant(),
+    )
+}

--- a/core-data/src/main/resources/db/migration/h2/V12__promo_schema.sql
+++ b/core-data/src/main/resources/db/migration/h2/V12__promo_schema.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS promo_links (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    promoter_user_id BIGINT NOT NULL REFERENCES users(id),
+    club_id BIGINT REFERENCES clubs(id),
+    utm_source VARCHAR(255) NOT NULL,
+    utm_medium VARCHAR(255) NOT NULL,
+    utm_campaign VARCHAR(255) NOT NULL,
+    utm_content VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_promo_links_promoter_club ON promo_links (promoter_user_id, club_id);
+
+CREATE TABLE IF NOT EXISTS promo_attribution (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    booking_id UUID NOT NULL REFERENCES bookings(id) ON DELETE CASCADE,
+    promo_link_id BIGINT NOT NULL REFERENCES promo_links(id) ON DELETE CASCADE,
+    promoter_user_id BIGINT NOT NULL REFERENCES users(id),
+    utm_source VARCHAR(255) NOT NULL,
+    utm_medium VARCHAR(255) NOT NULL,
+    utm_campaign VARCHAR(255) NOT NULL,
+    utm_content VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT uq_promo_attribution_booking UNIQUE (booking_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_promo_attribution_booking ON promo_attribution (booking_id);
+
+CREATE TABLE IF NOT EXISTS booking_templates (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    promoter_user_id BIGINT NOT NULL REFERENCES users(id),
+    club_id BIGINT NOT NULL REFERENCES clubs(id),
+    table_capacity_min INTEGER NOT NULL,
+    notes CLOB,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_booking_templates_owner ON booking_templates (promoter_user_id, club_id, is_active);

--- a/core-data/src/main/resources/db/migration/postgresql/V12__promo_schema.sql
+++ b/core-data/src/main/resources/db/migration/postgresql/V12__promo_schema.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS promo_links (
+    id BIGSERIAL PRIMARY KEY,
+    promoter_user_id BIGINT NOT NULL REFERENCES users(id),
+    club_id BIGINT REFERENCES clubs(id),
+    utm_source TEXT NOT NULL,
+    utm_medium TEXT NOT NULL,
+    utm_campaign TEXT NOT NULL,
+    utm_content TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_promo_links_promoter_club ON promo_links (promoter_user_id, club_id);
+
+CREATE TABLE IF NOT EXISTS promo_attribution (
+    id BIGSERIAL PRIMARY KEY,
+    booking_id UUID NOT NULL REFERENCES bookings(id) ON DELETE CASCADE,
+    promo_link_id BIGINT NOT NULL REFERENCES promo_links(id) ON DELETE CASCADE,
+    promoter_user_id BIGINT NOT NULL REFERENCES users(id),
+    utm_source TEXT NOT NULL,
+    utm_medium TEXT NOT NULL,
+    utm_campaign TEXT NOT NULL,
+    utm_content TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_promo_attribution_booking UNIQUE (booking_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_promo_attribution_booking ON promo_attribution (booking_id);
+
+CREATE TABLE IF NOT EXISTS booking_templates (
+    id BIGSERIAL PRIMARY KEY,
+    promoter_user_id BIGINT NOT NULL REFERENCES users(id),
+    club_id BIGINT NOT NULL REFERENCES clubs(id),
+    table_capacity_min INTEGER NOT NULL,
+    notes TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_booking_templates_owner ON booking_templates (promoter_user_id, club_id, is_active);

--- a/core-data/src/test/kotlin/com/example/bot/data/promo/PromoRepositoryIT.kt
+++ b/core-data/src/test/kotlin/com/example/bot/data/promo/PromoRepositoryIT.kt
@@ -1,0 +1,253 @@
+package com.example.bot.data.promo
+
+import com.example.bot.data.booking.BookingsTable
+import com.example.bot.data.club.PostgresClubIntegrationTest
+import com.example.bot.promo.BookingTemplateRepository
+import com.example.bot.promo.BookingTemplateResult
+import com.example.bot.promo.PromoAttributionError
+import com.example.bot.promo.PromoAttributionRepository
+import com.example.bot.promo.PromoAttributionResult
+import com.example.bot.promo.PromoLinkRepository
+import com.example.bot.promo.PromoLinkResult
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PromoRepositoryIT : PostgresClubIntegrationTest() {
+    private val fixedInstant: Instant = Instant.parse("2024-09-01T12:00:00Z")
+    private val fixedClock: Clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+    private val bookingSlotDuration: Duration = Duration.ofHours(3)
+
+    private lateinit var promoLinkRepository: PromoLinkRepository
+    private lateinit var promoAttributionRepository: PromoAttributionRepository
+    private lateinit var bookingTemplateRepository: BookingTemplateRepository
+
+    @BeforeEach
+    fun setUpRepositories() {
+        promoLinkRepository = PromoLinkRepositoryImpl(database, fixedClock)
+        promoAttributionRepository = PromoAttributionRepositoryImpl(database, fixedClock)
+        bookingTemplateRepository = BookingTemplateRepositoryImpl(database, fixedClock)
+        transaction(database) {
+            exec("TRUNCATE TABLE promo_attribution, promo_links, booking_templates RESTART IDENTITY CASCADE")
+        }
+    }
+
+    @Test
+    fun `promo link lifecycle`() = runBlocking {
+        val promoterId = insertUser(username = "promo", displayName = "Promo User")
+        val clubId = insertClub(name = "Nebula")
+
+        val created =
+            promoLinkRepository.issueLink(
+                promoterUserId = promoterId,
+                clubId = clubId,
+                utmSource = "telegram",
+                utmMedium = "bot",
+                utmCampaign = "launch",
+                utmContent = "banner",
+            )
+
+        assertEquals(promoterId, created.promoterUserId)
+        assertEquals(fixedInstant, created.createdAt)
+
+        val fetched = promoLinkRepository.get(created.id)
+        assertEquals(created, fetched)
+
+        val listed = promoLinkRepository.listByPromoter(promoterId, clubId)
+        assertEquals(listOf(created), listed)
+
+        val deactivateResult = promoLinkRepository.deactivate(created.id)
+        assertTrue(deactivateResult is PromoLinkResult.Success)
+
+        val afterRemoval = promoLinkRepository.get(created.id)
+        assertNull(afterRemoval)
+
+        val missing = promoLinkRepository.deactivate(created.id)
+        assertTrue(missing is PromoLinkResult.Failure)
+    }
+
+    @Test
+    fun `promo attribution enforces uniqueness per booking`() = runBlocking {
+        val promoterId = insertUser(username = "owner", displayName = "Owner")
+        val clubId = insertClub(name = "Aurora")
+        val eventId =
+            insertEvent(
+                clubId = clubId,
+                title = "Showcase",
+                startAt = fixedInstant.plus(Duration.ofHours(2)),
+                endAt = fixedInstant.plus(Duration.ofHours(6)),
+            )
+        val tableNumber = 12
+        val tableCapacity = 6
+        val guestCount = 4
+        val minDeposit = BigDecimal("150.00")
+        val tableId = insertTable(clubId = clubId, tableNumber = tableNumber, capacity = tableCapacity, minDeposit = minDeposit)
+
+        val promoLink =
+            promoLinkRepository.issueLink(
+                promoterUserId = promoterId,
+                clubId = clubId,
+                utmSource = "telegram",
+                utmMedium = "bot",
+                utmCampaign = "launch",
+                utmContent = null,
+            )
+
+        val bookingId =
+            insertBooking(
+                clubId = clubId,
+                tableId = tableId,
+                eventId = eventId,
+                tableNumber = tableNumber,
+                guests = guestCount,
+                promoterUserId = promoterId,
+                deposit = minDeposit,
+            )
+
+        val attached =
+            promoAttributionRepository.attachUnique(
+                bookingId = bookingId,
+                promoLinkId = promoLink.id,
+                promoterUserId = promoterId,
+                utmSource = "telegram",
+                utmMedium = "bot",
+                utmCampaign = "launch",
+                utmContent = "banner",
+            )
+        assertTrue(attached is PromoAttributionResult.Success)
+
+        val stored = (attached as PromoAttributionResult.Success).value
+        assertEquals(bookingId, stored.bookingId)
+        assertEquals(fixedInstant, stored.createdAt)
+
+        val fetched = promoAttributionRepository.findByBooking(bookingId)
+        assertEquals(stored, fetched)
+
+        val duplicate =
+            promoAttributionRepository.attachUnique(
+                bookingId = bookingId,
+                promoLinkId = promoLink.id,
+                promoterUserId = promoterId,
+                utmSource = "telegram",
+                utmMedium = "bot",
+                utmCampaign = "launch",
+                utmContent = "banner",
+            )
+        assertTrue(duplicate is PromoAttributionResult.Failure)
+        assertEquals(PromoAttributionError.AlreadyAttributed, (duplicate as PromoAttributionResult.Failure).error)
+    }
+
+    @Test
+    fun `booking template lifecycle`() = runBlocking {
+        val promoterId = insertUser(username = "templater", displayName = "Template Owner")
+        val clubId = insertClub(name = "Cosmos")
+        val initialCapacity = 4
+        val updatedCapacity = 6
+
+        val created =
+            bookingTemplateRepository.create(
+                promoterUserId = promoterId,
+                clubId = clubId,
+                tableCapacityMin = initialCapacity,
+                notes = "VIP",
+            )
+        assertEquals(fixedInstant, created.createdAt)
+        assertTrue(created.isActive)
+
+        val fetched = bookingTemplateRepository.get(created.id)
+        assertEquals(created, fetched)
+
+        val byOwner = bookingTemplateRepository.listByOwner(promoterId)
+        assertEquals(listOf(created), byOwner)
+
+        val byClub = bookingTemplateRepository.listByClub(clubId)
+        assertEquals(listOf(created), byClub)
+
+        val updateResult =
+            bookingTemplateRepository.update(
+                id = created.id,
+                tableCapacityMin = updatedCapacity,
+                notes = "Updated",
+                isActive = true,
+            )
+        assertTrue(updateResult is BookingTemplateResult.Success)
+        val updated = (updateResult as BookingTemplateResult.Success).value
+        assertEquals(updatedCapacity, updated.tableCapacityMin)
+        assertEquals("Updated", updated.notes)
+
+        val signatureResult = bookingTemplateRepository.applyTemplateSignature(updated.id)
+        assertTrue(signatureResult is BookingTemplateResult.Success)
+        val signature = (signatureResult as BookingTemplateResult.Success).value
+        assertEquals(updated.id, signature.templateId)
+        assertTrue(signature.value.isNotBlank())
+
+        val secondSignature = bookingTemplateRepository.applyTemplateSignature(updated.id)
+        assertTrue(secondSignature is BookingTemplateResult.Success)
+        assertEquals(signature.value, (secondSignature as BookingTemplateResult.Success).value.value)
+
+        val deactivateResult = bookingTemplateRepository.deactivate(updated.id)
+        assertTrue(deactivateResult is BookingTemplateResult.Success)
+
+        val activeTemplates = bookingTemplateRepository.listByClub(clubId)
+        assertTrue(activeTemplates.isEmpty())
+
+        val allTemplates = bookingTemplateRepository.listByClub(clubId, onlyActive = false)
+        assertEquals(1, allTemplates.size)
+        assertFalse(allTemplates.first().isActive)
+
+        val missing = bookingTemplateRepository.deactivate(updated.id + 1)
+        assertTrue(missing is BookingTemplateResult.Failure)
+    }
+
+    private fun insertBooking(
+        clubId: Long,
+        tableId: Long,
+        eventId: Long,
+        tableNumber: Int,
+        guests: Int,
+        promoterUserId: Long?,
+        deposit: BigDecimal,
+    ): UUID {
+        val bookingId = UUID.randomUUID()
+        val slotStart = fixedInstant.plus(Duration.ofHours(4))
+        val slotEnd = slotStart.plus(bookingSlotDuration)
+        val timestamp = fixedInstant.atOffset(ZoneOffset.UTC)
+        transaction(database) {
+            BookingsTable.insert {
+                it[BookingsTable.id] = bookingId
+                it[BookingsTable.eventId] = eventId
+                it[BookingsTable.clubId] = clubId
+                it[BookingsTable.tableId] = tableId
+                it[BookingsTable.tableNumber] = tableNumber
+                it[BookingsTable.guestUserId] = null
+                it[BookingsTable.guestName] = null
+                it[BookingsTable.phoneE164] = null
+                it[BookingsTable.promoterUserId] = promoterUserId
+                it[BookingsTable.guestsCount] = guests
+                it[BookingsTable.minDeposit] = deposit
+                it[BookingsTable.totalDeposit] = deposit
+                it[BookingsTable.slotStart] = slotStart.atOffset(ZoneOffset.UTC)
+                it[BookingsTable.slotEnd] = slotEnd.atOffset(ZoneOffset.UTC)
+                it[BookingsTable.arrivalBy] = null
+                it[BookingsTable.status] = "BOOKED"
+                it[BookingsTable.qrSecret] = UUID.randomUUID().toString().replace("-", "")
+                it[BookingsTable.idempotencyKey] = UUID.randomUUID().toString()
+                it[BookingsTable.createdAt] = timestamp
+                it[BookingsTable.updatedAt] = timestamp
+            }
+        }
+        return bookingId
+    }
+}

--- a/core-domain/src/main/kotlin/com/example/bot/promo/PromoModels.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/promo/PromoModels.kt
@@ -1,0 +1,126 @@
+package com.example.bot.promo
+
+import java.time.Instant
+import java.util.UUID
+
+/** Representation of a promo link that can be distributed by promoters. */
+data class PromoLink(
+    val id: Long,
+    val promoterUserId: Long,
+    val clubId: Long?,
+    val utmSource: String,
+    val utmMedium: String,
+    val utmCampaign: String,
+    val utmContent: String?,
+    val createdAt: Instant,
+)
+
+sealed interface PromoLinkError {
+    data object NotFound : PromoLinkError
+}
+
+sealed interface PromoLinkResult<out T> {
+    data class Success<T>(val value: T) : PromoLinkResult<T>
+    data class Failure(val error: PromoLinkError) : PromoLinkResult<Nothing>
+}
+
+interface PromoLinkRepository {
+    suspend fun issueLink(
+        promoterUserId: Long,
+        clubId: Long?,
+        utmSource: String,
+        utmMedium: String,
+        utmCampaign: String,
+        utmContent: String?,
+    ): PromoLink
+
+    suspend fun get(id: Long): PromoLink?
+
+    suspend fun listByPromoter(promoterUserId: Long, clubId: Long? = null): List<PromoLink>
+
+    suspend fun deactivate(id: Long): PromoLinkResult<Unit>
+}
+
+/** Representation of attribution between bookings and promo links. */
+data class PromoAttribution(
+    val id: Long,
+    val bookingId: UUID,
+    val promoLinkId: Long,
+    val promoterUserId: Long,
+    val utmSource: String,
+    val utmMedium: String,
+    val utmCampaign: String,
+    val utmContent: String?,
+    val createdAt: Instant,
+)
+
+sealed interface PromoAttributionError {
+    data object AlreadyAttributed : PromoAttributionError
+}
+
+sealed interface PromoAttributionResult<out T> {
+    data class Success<T>(val value: T) : PromoAttributionResult<T>
+    data class Failure(val error: PromoAttributionError) : PromoAttributionResult<Nothing>
+}
+
+interface PromoAttributionRepository {
+    suspend fun attachUnique(
+        bookingId: UUID,
+        promoLinkId: Long,
+        promoterUserId: Long,
+        utmSource: String,
+        utmMedium: String,
+        utmCampaign: String,
+        utmContent: String?,
+    ): PromoAttributionResult<PromoAttribution>
+
+    suspend fun findByBooking(bookingId: UUID): PromoAttribution?
+}
+
+/** Template for booking creation shortcuts. */
+data class BookingTemplate(
+    val id: Long,
+    val promoterUserId: Long,
+    val clubId: Long,
+    val tableCapacityMin: Int,
+    val notes: String?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+)
+
+data class BookingTemplateSignature(val templateId: Long, val value: String)
+
+sealed interface BookingTemplateError {
+    data object NotFound : BookingTemplateError
+}
+
+sealed interface BookingTemplateResult<out T> {
+    data class Success<T>(val value: T) : BookingTemplateResult<T>
+    data class Failure(val error: BookingTemplateError) : BookingTemplateResult<Nothing>
+}
+
+interface BookingTemplateRepository {
+    suspend fun create(
+        promoterUserId: Long,
+        clubId: Long,
+        tableCapacityMin: Int,
+        notes: String?,
+    ): BookingTemplate
+
+    suspend fun update(
+        id: Long,
+        tableCapacityMin: Int,
+        notes: String?,
+        isActive: Boolean,
+    ): BookingTemplateResult<BookingTemplate>
+
+    suspend fun deactivate(id: Long): BookingTemplateResult<Unit>
+
+    suspend fun get(id: Long): BookingTemplate?
+
+    suspend fun listByOwner(promoterUserId: Long): List<BookingTemplate>
+
+    suspend fun listByClub(clubId: Long, onlyActive: Boolean = true): List<BookingTemplate>
+
+    suspend fun applyTemplateSignature(id: Long): BookingTemplateResult<BookingTemplateSignature>
+}


### PR DESCRIPTION
## Summary
- add promo domain models and repository interfaces for promo links, attributions, and booking templates
- implement Exposed repositories with transactional retry logic and template signature hashing
- create vendor-specific migrations and integration tests covering CRUD flows and attribution uniqueness

## Testing
- ./gradlew clean build test detekt --console=plain
- ./gradlew clean build test detekt -PrunIT=true --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cedcb1f5408321ba958294d3d5a13f