### PR TITLE
Add promoter booking templates flow and tests

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/di/BookingModules.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/di/BookingModules.kt
@@ -5,6 +5,7 @@ import com.example.bot.data.booking.core.AuditLogRepository
 import com.example.bot.data.booking.core.BookingHoldRepository
 import com.example.bot.data.booking.core.BookingRepository
 import com.example.bot.data.booking.core.OutboxRepository
+import com.example.bot.data.promo.BookingTemplateRepositoryImpl
 import com.example.bot.data.promo.PromoAttributionRepositoryImpl
 import com.example.bot.data.promo.PromoLinkRepositoryImpl
 import com.example.bot.data.security.ExposedUserRepository
@@ -14,6 +15,8 @@ import com.example.bot.promo.InMemoryPromoAttributionStore
 import com.example.bot.promo.PromoAttributionCoordinator
 import com.example.bot.promo.PromoAttributionService
 import com.example.bot.promo.PromoAttributionStore
+import com.example.bot.promo.BookingTemplateRepository
+import com.example.bot.promo.BookingTemplateService
 import com.example.bot.workers.OutboxWorker
 import com.example.bot.workers.SendOutcome
 import com.example.bot.workers.SendPort
@@ -32,11 +35,13 @@ val bookingModule = module {
     single { AuditLogRepository(get()) }
     single { PromoLinkRepositoryImpl(get()) }
     single { PromoAttributionRepositoryImpl(get()) }
+    single<BookingTemplateRepository> { BookingTemplateRepositoryImpl(get()) }
     single { ExposedUserRepository(get()) }
     single { ExposedUserRoleRepository(get()) }
     single<PromoAttributionStore> { InMemoryPromoAttributionStore() }
     single { PromoAttributionService(get(), get(), get(), get(), get()) }
     single<PromoAttributionCoordinator> { get<PromoAttributionService>() }
+    single { BookingTemplateService(get(), get(), get(), get()) }
     single<SendPort> { DummySendPort }
     single { BookingService(get(), get(), get(), get(), get()) }
     single { OutboxWorker(get(), get()) }

--- a/app-bot/src/main/kotlin/com/example/bot/promo/BookingTemplateService.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/promo/BookingTemplateService.kt
@@ -1,0 +1,214 @@
+package com.example.bot.promo
+
+import com.example.bot.booking.BookingCmdResult
+import com.example.bot.booking.BookingService
+import com.example.bot.booking.HoldRequest
+import com.example.bot.data.security.Role
+import com.example.bot.data.security.UserRepository
+import com.example.bot.data.security.UserRoleRepository
+import java.time.Duration
+import java.time.Instant
+import java.util.LinkedHashMap
+import java.util.UUID
+
+private val DEFAULT_HOLD_TTL: Duration = Duration.ofMinutes(15)
+
+/** Actor resolved from Telegram interaction with assigned roles and club scope. */
+data class TemplateActor(
+    val userId: Long,
+    val telegramUserId: Long,
+    val roles: Set<Role>,
+    val clubIds: Set<Long>,
+)
+
+/** Request for creating a booking template. */
+data class TemplateCreateRequest(
+    val promoterUserId: Long,
+    val clubId: Long,
+    val tableCapacityMin: Int,
+    val notes: String?,
+)
+
+/** Request for updating existing template. */
+data class TemplateUpdateRequest(
+    val id: Long,
+    val tableCapacityMin: Int,
+    val notes: String?,
+    val isActive: Boolean,
+)
+
+/** Parameters required to apply template when creating booking. */
+data class TemplateBookingRequest(
+    val clubId: Long,
+    val tableId: Long,
+    val slotStart: Instant,
+    val slotEnd: Instant,
+    val guestsOverride: Int? = null,
+    val holdTtl: Duration = DEFAULT_HOLD_TTL,
+)
+
+class TemplateAccessException(message: String) : RuntimeException(message)
+
+class TemplateNotFoundException(message: String) : RuntimeException(message)
+
+/**
+ * Service that enforces RBAC rules for booking templates and orchestrates booking flow.
+ */
+class BookingTemplateService(
+    private val repository: BookingTemplateRepository,
+    private val bookingService: BookingService,
+    private val userRepository: UserRepository,
+    private val userRoleRepository: UserRoleRepository,
+) {
+    suspend fun resolveActor(telegramUserId: Long): TemplateActor? {
+        val user = userRepository.getByTelegramId(telegramUserId) ?: return null
+        val roles = userRoleRepository.listRoles(user.id)
+        val clubIds = userRoleRepository.listClubIdsFor(user.id)
+        return TemplateActor(userId = user.id, telegramUserId = user.telegramId, roles = roles, clubIds = clubIds)
+    }
+
+    suspend fun createTemplate(actor: TemplateActor, request: TemplateCreateRequest): BookingTemplate {
+        ensureCanCreate(actor, request.promoterUserId, request.clubId)
+        return repository.create(
+            promoterUserId = request.promoterUserId,
+            clubId = request.clubId,
+            tableCapacityMin = request.tableCapacityMin,
+            notes = request.notes,
+        )
+    }
+
+    suspend fun listTemplates(
+        actor: TemplateActor,
+        clubId: Long? = null,
+        onlyActive: Boolean = true,
+    ): List<BookingTemplate> {
+        return when {
+            Role.PROMOTER in actor.roles ->
+                repository
+                    .listByOwner(actor.userId)
+                    .filter { clubId == null || it.clubId == clubId }
+            else -> {
+                val clubs = determineClubScope(actor, clubId)
+                val seen = LinkedHashMap<Long, BookingTemplate>()
+                for (id in clubs) {
+                    val templates = repository.listByClub(id, onlyActive)
+                    for (template in templates) {
+                        if (actor.canAccess(template)) {
+                            seen.putIfAbsent(template.id, template)
+                        }
+                    }
+                }
+                seen.values.toList()
+            }
+        }
+    }
+
+    suspend fun updateTemplate(actor: TemplateActor, request: TemplateUpdateRequest): BookingTemplate {
+        val template = repository.get(request.id) ?: throw TemplateNotFoundException("template ${request.id} not found")
+        ensureCanAccess(actor, template)
+        return when (val result = repository.update(request.id, request.tableCapacityMin, request.notes, request.isActive)) {
+            is BookingTemplateResult.Success -> result.value
+            is BookingTemplateResult.Failure -> throw TemplateNotFoundException("template ${request.id} not found")
+        }
+    }
+
+    suspend fun deactivateTemplate(actor: TemplateActor, id: Long) {
+        val template = repository.get(id) ?: throw TemplateNotFoundException("template $id not found")
+        ensureCanAccess(actor, template)
+        when (repository.deactivate(id)) {
+            is BookingTemplateResult.Success -> Unit
+            is BookingTemplateResult.Failure -> throw TemplateNotFoundException("template $id not found")
+        }
+    }
+
+    suspend fun applyTemplate(
+        actor: TemplateActor,
+        templateId: Long,
+        request: TemplateBookingRequest,
+    ): BookingCmdResult {
+        val template = repository.get(templateId) ?: throw TemplateNotFoundException("template $templateId not found")
+        ensureCanAccess(actor, template)
+        if (!template.isActive) {
+            throw TemplateAccessException("template $templateId is inactive")
+        }
+        if (request.clubId != template.clubId) {
+            throw TemplateAccessException("template $templateId cannot be applied to club ${request.clubId}")
+        }
+        val guests = request.guestsOverride ?: template.tableCapacityMin
+        val holdIdempotency = "tpl-hold-${templateId}-${UUID.randomUUID()}"
+        val holdResult =
+            bookingService.hold(
+                HoldRequest(
+                    clubId = template.clubId,
+                    tableId = request.tableId,
+                    slotStart = request.slotStart,
+                    slotEnd = request.slotEnd,
+                    guestsCount = guests,
+                    ttl = request.holdTtl,
+                ),
+                holdIdempotency,
+            )
+        if (holdResult !is BookingCmdResult.HoldCreated) {
+            return holdResult
+        }
+        val confirmKey = "tpl-confirm-${templateId}-${UUID.randomUUID()}"
+        return when (val confirmed = bookingService.confirm(holdResult.holdId, confirmKey)) {
+            is BookingCmdResult.Booked -> {
+                bookingService.finalize(confirmed.bookingId, actor.telegramUserId)
+            }
+            is BookingCmdResult.AlreadyBooked -> confirmed
+            else -> confirmed
+        }
+    }
+
+    private fun ensureCanCreate(actor: TemplateActor, promoterId: Long, clubId: Long) {
+        val allowed =
+            when {
+                actor.hasRole(Role.OWNER, Role.HEAD_MANAGER) -> true
+                actor.hasRole(Role.CLUB_ADMIN, Role.MANAGER) -> clubId in actor.clubIds
+                actor.hasRole(Role.PROMOTER) -> promoterId == actor.userId && clubId in actor.clubIds
+                else -> false
+            }
+        if (!allowed) {
+            throw TemplateAccessException("actor ${actor.userId} cannot create template for club $clubId")
+        }
+    }
+
+    private fun ensureCanAccess(actor: TemplateActor, template: BookingTemplate) {
+        if (!actor.canAccess(template)) {
+            throw TemplateAccessException("actor ${actor.userId} cannot access template ${template.id}")
+        }
+    }
+
+    private fun TemplateActor.canAccess(template: BookingTemplate): Boolean {
+        return when {
+            hasRole(Role.OWNER, Role.HEAD_MANAGER) -> true
+            hasRole(Role.CLUB_ADMIN, Role.MANAGER) -> template.clubId in clubIds
+            hasRole(Role.PROMOTER) -> template.promoterUserId == userId
+            else -> false
+        }
+    }
+
+    private fun determineClubScope(actor: TemplateActor, requestedClub: Long?): Set<Long> {
+        val privileged = actor.hasRole(Role.OWNER, Role.HEAD_MANAGER)
+        val scopedRoles = actor.hasRole(Role.CLUB_ADMIN, Role.MANAGER)
+        return when {
+            privileged ->
+                when {
+                    requestedClub != null -> setOf(requestedClub)
+                    actor.clubIds.isNotEmpty() -> actor.clubIds
+                    else -> emptySet()
+                }
+            scopedRoles -> {
+                val clubs = if (requestedClub != null) setOf(requestedClub) else actor.clubIds
+                if (clubs.isEmpty() || (requestedClub != null && requestedClub !in actor.clubIds)) {
+                    throw TemplateAccessException("club scope missing for actor ${actor.userId}")
+                }
+                clubs
+            }
+            else -> emptySet()
+        }
+    }
+
+    private fun TemplateActor.hasRole(vararg target: Role): Boolean = roles.any { it in target }
+}

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/TemplatesHandler.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/TemplatesHandler.kt
@@ -1,0 +1,101 @@
+package com.example.bot.telegram
+
+import com.example.bot.promo.BookingTemplate
+import com.example.bot.promo.BookingTemplateService
+import com.example.bot.promo.TemplateActor
+import com.example.bot.promo.TemplateBookingRequest
+import com.example.bot.telegram.ott.CallbackTokenService
+import com.example.bot.telegram.ott.TemplateOttPayload
+import com.pengrad.telegrambot.model.request.InlineKeyboardButton
+import com.pengrad.telegrambot.model.request.InlineKeyboardMarkup
+import java.time.Instant
+
+private const val ACTION_LIST = "tpl:list"
+private const val ACTION_CREATE = "tpl:new"
+private const val ACTION_BOOK = "tpl:book"
+
+/**
+ * Handler responsible for booking template bot interactions.
+ */
+class BookingTemplateBotHandler(
+    private val service: BookingTemplateService,
+    private val tokenService: CallbackTokenService,
+) {
+    /** Builds a menu keyboard with template actions. */
+    fun buildMenu(): InlineKeyboardMarkup {
+        return InlineKeyboardMarkup(
+            arrayOf(InlineKeyboardButton("Мои шаблоны").callbackData(ACTION_LIST)),
+            arrayOf(InlineKeyboardButton("Создать шаблон").callbackData(ACTION_CREATE)),
+            arrayOf(InlineKeyboardButton("Забронировать по шаблону").callbackData(ACTION_BOOK)),
+        )
+    }
+
+    /**
+     * Issues OTT tokens for templates and produces keyboard for selection.
+     */
+    fun buildTemplateSelection(templates: List<BookingTemplate>): InlineKeyboardMarkup {
+        if (templates.isEmpty()) {
+            return InlineKeyboardMarkup(arrayOf(InlineKeyboardButton("Нет шаблонов").callbackData("tpl:none")))
+        }
+        val rows = templates.map { template ->
+            val payload = TemplateOttPayload.Selection(template.id)
+            val token = tokenService.issueToken(payload)
+            arrayOf(
+                InlineKeyboardButton("Шаблон #${template.id} · ${template.tableCapacityMin} гостей").callbackData(token),
+            )
+        }
+        return InlineKeyboardMarkup(*rows.toTypedArray())
+    }
+
+    /** Decodes OTT payload stored in callback token. */
+    fun decode(token: String): TemplateOttPayload? = tokenService.consume(token) as? TemplateOttPayload
+
+    /** Issues OTT payload for booking command to stay within callback limits. */
+    fun issueBookingToken(payload: TemplateBookingCommandPayload): String {
+        val ottPayload =
+            TemplateOttPayload.Booking(
+                templateId = payload.templateId,
+                clubId = payload.clubId,
+                tableId = payload.tableId,
+                slotStart = payload.slotStart,
+                slotEnd = payload.slotEnd,
+                guests = payload.guests,
+            )
+        return tokenService.issueToken(ottPayload)
+    }
+
+    suspend fun listTemplates(actor: TemplateActor, clubId: Long? = null): List<BookingTemplate> {
+        return service.listTemplates(actor, clubId, onlyActive = false)
+    }
+
+    suspend fun applyBooking(actor: TemplateActor, payload: TemplateOttPayload.Booking) =
+        service.applyTemplate(
+            actor = actor,
+            templateId = payload.templateId,
+            request =
+                TemplateBookingRequest(
+                    clubId = payload.clubId,
+                    tableId = payload.tableId,
+                    slotStart = payload.slotStart,
+                    slotEnd = payload.slotEnd,
+                    guestsOverride = payload.guests,
+                ),
+        )
+}
+
+/** Command button descriptors kept for convenience. */
+object TemplateMenuActions {
+    const val LIST = ACTION_LIST
+    const val CREATE = ACTION_CREATE
+    const val BOOK = ACTION_BOOK
+}
+
+/** Parameters for issuing booking OTT tokens. */
+data class TemplateBookingCommandPayload(
+    val templateId: Long,
+    val clubId: Long,
+    val tableId: Long,
+    val slotStart: Instant,
+    val slotEnd: Instant,
+    val guests: Int? = null,
+)

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/ott/CallbackTokenService.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/ott/CallbackTokenService.kt
@@ -1,5 +1,6 @@
 package com.example.bot.telegram.ott
 
+import com.example.bot.telegram.ott.TemplateOttPayload
 import com.pengrad.telegrambot.TelegramBot
 import com.pengrad.telegrambot.model.CallbackQuery
 import com.pengrad.telegrambot.model.Update
@@ -49,7 +50,10 @@ class CallbackQueryHandler(
             else -> {
                 when (payload) {
                     is BookTableAction -> handleBookTable(callbackQuery, payload)
-                    // добавляйте другие типы payload тут
+                    is TemplateOttPayload -> {
+                        bot.execute(AnswerCallbackQuery(callbackQuery.id()))
+                        Unit
+                    }
                 }
             }
         }

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/ott/TemplateOttPayloads.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/ott/TemplateOttPayloads.kt
@@ -1,0 +1,17 @@
+package com.example.bot.telegram.ott
+
+import java.time.Instant
+
+/** Payload stored inside OTT callback tokens for template actions. */
+sealed interface TemplateOttPayload : OttPayload {
+    data class Selection(val templateId: Long) : TemplateOttPayload
+
+    data class Booking(
+        val templateId: Long,
+        val clubId: Long,
+        val tableId: Long,
+        val slotStart: Instant,
+        val slotEnd: Instant,
+        val guests: Int?,
+    ) : TemplateOttPayload
+}

--- a/app-bot/src/test/kotlin/com/example/bot/telegram/BookingTemplateFlowIT.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/telegram/BookingTemplateFlowIT.kt
@@ -1,0 +1,286 @@
+package com.example.bot.telegram
+
+import com.example.bot.booking.BookingCmdResult
+import com.example.bot.booking.BookingService
+import com.example.bot.data.booking.core.BookingOutboxTable
+import com.example.bot.data.booking.BookingsTable
+import com.example.bot.data.booking.EventsTable
+import com.example.bot.data.booking.TablesTable
+import com.example.bot.data.db.Clubs
+import com.example.bot.data.promo.BookingTemplateRepositoryImpl
+import com.example.bot.data.security.ExposedUserRepository
+import com.example.bot.data.security.ExposedUserRoleRepository
+import com.example.bot.data.security.Role
+import com.example.bot.promo.BookingTemplateService
+import com.example.bot.promo.TemplateAccessException
+import com.example.bot.promo.TemplateActor
+import com.example.bot.promo.TemplateBookingRequest
+import com.example.bot.promo.TemplateCreateRequest
+import com.example.bot.promo.TemplateUpdateRequest
+import com.example.bot.testing.PostgresAppTest
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+private object TestUsersTable : org.jetbrains.exposed.sql.Table("users") {
+    val id = long("id").autoIncrement()
+    val telegramUserId = long("telegram_user_id").nullable()
+    val username = text("username").nullable()
+    val displayName = text("display_name").nullable()
+    val phone = text("phone_e164").nullable()
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object TestUserRolesTable : org.jetbrains.exposed.sql.Table("user_roles") {
+    val id = long("id").autoIncrement()
+    val userId = long("user_id")
+    val roleCode = text("role_code")
+    val scopeType = text("scope_type")
+    val scopeClubId = long("scope_club_id").nullable()
+    override val primaryKey = PrimaryKey(id)
+}
+
+class BookingTemplateFlowIT : PostgresAppTest() {
+    private val fixedInstant: Instant = Instant.parse("2025-04-10T18:00:00Z")
+    private val clock: Clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+
+    private lateinit var bookingService: BookingService
+    private lateinit var templateService: BookingTemplateService
+    private lateinit var userRepository: ExposedUserRepository
+    private lateinit var userRoleRepository: ExposedUserRoleRepository
+
+    @BeforeEach
+    fun setUpServices() {
+        val bookingRepository = com.example.bot.data.booking.core.BookingRepository(database, clock)
+        val holdRepository = com.example.bot.data.booking.core.BookingHoldRepository(database, clock)
+        val outboxRepository = com.example.bot.data.booking.core.OutboxRepository(database, clock)
+        val auditRepository = com.example.bot.data.booking.core.AuditLogRepository(database, clock)
+        bookingService = BookingService(bookingRepository, holdRepository, outboxRepository, auditRepository)
+        val templateRepository = BookingTemplateRepositoryImpl(database, clock)
+        userRepository = ExposedUserRepository(database)
+        userRoleRepository = ExposedUserRoleRepository(database)
+        templateService = BookingTemplateService(templateRepository, bookingService, userRepository, userRoleRepository)
+    }
+
+    @Test
+    fun `rbac rules enforced for template lifecycle`() = runBlocking {
+        val clubOne = insertClub("Orion")
+        val clubTwo = insertClub("Andromeda")
+
+        val promoterOneId = insertUser(telegramId = 101L, username = "promoter1")
+        val promoterTwoId = insertUser(telegramId = 102L, username = "promoter2")
+        val managerId = insertUser(telegramId = 201L, username = "manager")
+        val ownerId = insertUser(telegramId = 301L, username = "owner")
+
+        assignRole(promoterOneId, Role.PROMOTER, clubOne)
+        assignRole(promoterTwoId, Role.PROMOTER, clubTwo)
+        assignRole(managerId, Role.MANAGER, clubOne)
+        assignRole(ownerId, Role.OWNER, null)
+
+        val promoterOne = actor(101L)
+        val promoterTwo = actor(102L)
+        val manager = actor(201L)
+        val owner = actor(301L)
+
+        val templateOne =
+            templateService.createTemplate(
+                promoterOne,
+                TemplateCreateRequest(
+                    promoterUserId = promoterOne.userId,
+                    clubId = clubOne,
+                    tableCapacityMin = 4,
+                    notes = "VIP",
+                ),
+            )
+        val templateTwo =
+            templateService.createTemplate(
+                promoterTwo,
+                TemplateCreateRequest(
+                    promoterUserId = promoterTwo.userId,
+                    clubId = clubTwo,
+                    tableCapacityMin = 2,
+                    notes = "BAR",
+                ),
+            )
+
+        val ownTemplates = templateService.listTemplates(promoterOne)
+        assertEquals(listOf(templateOne.id), ownTemplates.map { it.id })
+
+        try {
+            templateService.updateTemplate(
+                promoterOne,
+                TemplateUpdateRequest(
+                    id = templateTwo.id,
+                    tableCapacityMin = 3,
+                    notes = "updated",
+                    isActive = true,
+                ),
+            )
+            fail("expected TemplateAccessException")
+        } catch (_: TemplateAccessException) {
+            // expected
+        }
+
+        val managerTemplates = templateService.listTemplates(manager, clubId = clubOne, onlyActive = false)
+        assertEquals(listOf(templateOne.id), managerTemplates.map { it.id })
+        try {
+            templateService.listTemplates(manager, clubId = clubTwo, onlyActive = false)
+            fail("expected TemplateAccessException")
+        } catch (_: TemplateAccessException) {
+            // expected
+        }
+
+        val updated =
+            templateService.updateTemplate(
+                manager,
+                TemplateUpdateRequest(
+                    id = templateOne.id,
+                    tableCapacityMin = 5,
+                    notes = "updated",
+                    isActive = true,
+                ),
+            )
+        assertEquals(5, updated.tableCapacityMin)
+
+        val ownerView = templateService.listTemplates(owner, clubId = clubTwo, onlyActive = false)
+        assertEquals(listOf(templateTwo.id), ownerView.map { it.id })
+    }
+
+    @Test
+    fun `apply template books table and enqueues notification`() = runBlocking {
+        val clubId = insertClub("Nova")
+        val promoterId = insertUser(telegramId = 501L, username = "nova-promoter")
+        val managerId = insertUser(telegramId = 502L, username = "nova-manager")
+        assignRole(promoterId, Role.PROMOTER, clubId)
+        assignRole(managerId, Role.MANAGER, clubId)
+
+        val start = fixedInstant.plusSeconds(3_600)
+        val end = start.plusSeconds(10_800)
+        insertEvent(clubId, start, end)
+        val tableId = insertTable(clubId, tableNumber = 10, capacity = 6, deposit = BigDecimal("150.00"))
+
+        val promoter = actor(501L)
+        val template =
+            templateService.createTemplate(
+                promoter,
+                TemplateCreateRequest(
+                    promoterUserId = promoter.userId,
+                    clubId = clubId,
+                    tableCapacityMin = 4,
+                    notes = null,
+                ),
+            )
+
+        val result =
+            templateService.applyTemplate(
+                promoter,
+                template.id,
+                TemplateBookingRequest(
+                    clubId = clubId,
+                    tableId = tableId,
+                    slotStart = start,
+                    slotEnd = end,
+                ),
+            )
+        assertTrue(result is BookingCmdResult.Booked)
+
+        transaction(database) {
+            val bookings = BookingsTable.select { BookingsTable.tableId eq tableId }.toList()
+            assertEquals(1, bookings.size)
+            val record = bookings.first()
+            assertEquals(start, record[BookingsTable.slotStart].toInstant())
+            assertEquals(end, record[BookingsTable.slotEnd].toInstant())
+        }
+
+        transaction(database) {
+            val outboxCount = BookingOutboxTable.select { BookingOutboxTable.topic eq "booking.confirmed" }.count()
+            assertEquals(1, outboxCount)
+        }
+    }
+
+    private suspend fun actor(telegramId: Long): TemplateActor =
+        templateService.resolveActor(telegramId) ?: error("actor $telegramId not found")
+
+    private fun insertClub(name: String): Long {
+        val id =
+            transaction(database) {
+                Clubs.insert { table ->
+                    table[Clubs.name] = name
+                    table[Clubs.description] = "$name club"
+                    table[Clubs.adminChatId] = null
+                    table[Clubs.timezone] = "UTC"
+                    table[Clubs.generalTopicId] = null
+                    table[Clubs.bookingsTopicId] = null
+                    table[Clubs.listsTopicId] = null
+                    table[Clubs.qaTopicId] = null
+                    table[Clubs.mediaTopicId] = null
+                    table[Clubs.systemTopicId] = null
+                } get Clubs.id
+            }
+        return id.value.toLong()
+    }
+
+    private fun insertEvent(clubId: Long, start: Instant, end: Instant): Long {
+        return transaction(database) {
+            EventsTable.insert { row ->
+                row[EventsTable.clubId] = clubId
+                row[EventsTable.title] = "Show"
+                row[EventsTable.startAt] = OffsetDateTime.ofInstant(start, ZoneOffset.UTC)
+                row[EventsTable.endAt] = OffsetDateTime.ofInstant(end, ZoneOffset.UTC)
+                row[EventsTable.isSpecial] = false
+                row[EventsTable.posterUrl] = null
+            } get EventsTable.id
+        }
+    }
+
+    private fun insertTable(clubId: Long, tableNumber: Int, capacity: Int, deposit: BigDecimal): Long {
+        return transaction(database) {
+            TablesTable.insert { row ->
+                row[TablesTable.clubId] = clubId
+                row[TablesTable.zoneId] = null
+                row[TablesTable.tableNumber] = tableNumber
+                row[TablesTable.capacity] = capacity
+                row[TablesTable.minDeposit] = deposit
+                row[TablesTable.active] = true
+            } get TablesTable.id
+        }
+    }
+
+    private fun insertUser(telegramId: Long, username: String): Long {
+        return transaction(database) {
+            TestUsersTable.insert { row ->
+                row[TestUsersTable.telegramUserId] = telegramId
+                row[TestUsersTable.username] = username
+                row[TestUsersTable.displayName] = username
+                row[TestUsersTable.phone] = null
+            } get TestUsersTable.id
+        }
+    }
+
+    private fun assignRole(userId: Long, role: Role, clubId: Long?) {
+        transaction(database) {
+            TestUserRolesTable.insert { row ->
+                row[TestUserRolesTable.userId] = userId
+                row[TestUserRolesTable.roleCode] = role.name
+                if (clubId != null) {
+                    row[TestUserRolesTable.scopeType] = "CLUB"
+                    row[TestUserRolesTable.scopeClubId] = clubId
+                } else {
+                    row[TestUserRolesTable.scopeType] = "GLOBAL"
+                    row[TestUserRolesTable.scopeClubId] = null
+                }
+            }
+        }
+    }
+}

--- a/app-bot/src/test/kotlin/com/example/bot/telegram/BookingTemplateOttPayloadTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/telegram/BookingTemplateOttPayloadTest.kt
@@ -1,0 +1,34 @@
+package com.example.bot.telegram
+
+import com.example.bot.telegram.ott.TemplateOttPayload.Booking
+import com.example.bot.telegram.ott.CallbackTokenService
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BookingTemplateOttPayloadTest {
+    private val tokenService = CallbackTokenService()
+
+    @Test
+    fun `booking payload round trip`() {
+        val payload =
+            Booking(
+                templateId = 12L,
+                clubId = 34L,
+                tableId = 56L,
+                slotStart = Instant.parse("2025-05-01T18:00:00Z"),
+                slotEnd = Instant.parse("2025-05-01T21:00:00Z"),
+                guests = 4,
+            )
+        val token = tokenService.issueToken(payload)
+        assertTrue(token.length <= 64)
+
+        val decoded = tokenService.consume(token) as? Booking
+        assertEquals(payload, decoded)
+
+        val replay = tokenService.consume(token)
+        assertNull(replay)
+    }
+}

--- a/app-bot/src/test/kotlin/com/example/bot/testing/PostgresAppTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/testing/PostgresAppTest.kt
@@ -47,7 +47,8 @@ abstract class PostgresAppTest {
         check(::database.isInitialized) { "database not initialised" }
         transaction(database) {
             exec(
-                "TRUNCATE TABLE booking_outbox, audit_log, booking_holds, bookings, events, tables, clubs RESTART IDENTITY CASCADE",
+                "TRUNCATE TABLE booking_outbox, audit_log, booking_holds, bookings, events, tables, clubs, " +
+                    "booking_templates, promo_links, promo_attribution, user_roles, users RESTART IDENTITY CASCADE",
             )
         }
     }


### PR DESCRIPTION
## Summary
- introduce `BookingTemplateService` with RBAC enforcement and booking orchestration
- add template bot handler with OTT payload support and expose dependencies via DI
- cover OTT token roundtrip and template flow scenarios with integration tests

## Testing
- ./gradlew app-bot:test --rerun-tasks --console plain

------
https://chatgpt.com/codex/tasks/task_e_68cee66290b4832180532afe9ce7010c