### PR TITLE
Implement guest list import-export flows with RBAC

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/routes/GuestListRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/GuestListRoutes.kt
@@ -1,0 +1,377 @@
+package com.example.bot.routes
+
+import com.example.bot.club.GuestList
+import com.example.bot.club.GuestListEntrySearch
+import com.example.bot.club.GuestListEntryStatus
+import com.example.bot.club.GuestListEntryView
+import com.example.bot.club.GuestListOwnerType
+import com.example.bot.club.GuestListRepository
+import com.example.bot.club.RejectedRow
+import com.example.bot.data.club.GuestListCsvParser
+import com.example.bot.data.security.Role
+import com.example.bot.security.rbac.authorize
+import com.example.bot.security.rbac.RbacContext
+import com.example.bot.security.rbac.rbacContext
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.acceptItems
+import io.ktor.server.request.contentType
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.util.getOrFail
+import kotlinx.serialization.Serializable
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import kotlin.io.use
+
+/** Registers guest list management routes. */
+fun Application.guestListRoutes(repository: GuestListRepository, parser: GuestListCsvParser) {
+    routing {
+        authorize(
+            Role.OWNER,
+            Role.GLOBAL_ADMIN,
+            Role.HEAD_MANAGER,
+            Role.CLUB_ADMIN,
+            Role.MANAGER,
+            Role.ENTRY_MANAGER,
+            Role.PROMOTER,
+        ) {
+            get("/api/guest-lists") {
+                val context = call.rbacContext()
+                val query = call.extractSearch(context)
+                if (query.forbidden) {
+                    call.respond(HttpStatusCode.Forbidden, mapOf("error" to "forbidden"))
+                    return@get
+                }
+                if (query.empty) {
+                    call.respond(GuestListPageResponse(emptyList(), total = 0, page = query.page, size = query.size))
+                    return@get
+                }
+                val result =
+                    repository.searchEntries(
+                        query.filter!!,
+                        page = query.page,
+                        size = query.size,
+                    )
+                val response =
+                    GuestListPageResponse(
+                        items = result.items.map { it.toResponse() },
+                        total = result.total,
+                        page = query.page,
+                        size = query.size,
+                    )
+                call.respond(response)
+            }
+
+            get("/api/guest-lists/export") {
+                val context = call.rbacContext()
+                val query = call.extractSearch(context)
+                if (query.forbidden) {
+                    call.respond(HttpStatusCode.Forbidden, mapOf("error" to "forbidden"))
+                    return@get
+                }
+                val items =
+                    if (query.empty) {
+                        emptyList()
+                    } else {
+                        repository.searchEntries(query.filter!!, page = query.page, size = query.size).items
+                    }
+                val csv = items.toExportCsv()
+                call.respondText(csv, ContentType.Text.CSV)
+            }
+
+            post("/api/guest-lists/{listId}/import") {
+                val listIdParam = call.parameters.getOrFail("listId")
+                val listId = listIdParam.toLongOrNull() ?: throw BadRequestException("Invalid listId")
+                val list = repository.getList(listId) ?: throw BadRequestException("List not found")
+                val context = call.rbacContext()
+                if (!context.canAccess(list)) {
+                    call.respond(HttpStatusCode.Forbidden, mapOf("error" to "forbidden"))
+                    return@post
+                }
+                val dryRun = call.request.queryParameters["dry_run"].toBooleanStrictOrNull() ?: false
+                val type = call.request.contentType()
+                if (!type.match(ContentType.Text.CSV) && type != TSV_CONTENT_TYPE) {
+                    throw BadRequestException("Expected text/csv body")
+                }
+                val payload = call.receiveText()
+                if (payload.isBlank()) {
+                    throw BadRequestException("Empty body")
+                }
+                val report =
+                    runCatching {
+                        performGuestListImport(
+                            repository = repository,
+                            parser = parser,
+                            listId = listId,
+                            input = payload.byteInputStream(StandardCharsets.UTF_8),
+                            dryRun = dryRun,
+                        )
+                    }.getOrElse { ex ->
+                        throw BadRequestException(ex.message ?: "Import failed")
+                    }
+                val wantsCsv = call.wantsCsv()
+                if (wantsCsv) {
+                    call.respondText(report.toCsv(), ContentType.Text.CSV)
+                } else {
+                    call.respond(report.toResponse())
+                }
+            }
+        }
+    }
+}
+
+internal data class GuestListImportReport(val accepted: Int, val rejected: List<RejectedRow>)
+
+internal suspend fun performGuestListImport(
+    repository: GuestListRepository,
+    parser: GuestListCsvParser,
+    listId: Long,
+    input: InputStream,
+    dryRun: Boolean,
+): GuestListImportReport {
+    return input.use { stream ->
+        val parsed = parser.parse(stream)
+        val importResult = repository.bulkImport(listId, parsed.rows, dryRun)
+        val rejected =
+            if (parsed.rejected.isEmpty()) {
+                importResult.rejected
+            } else {
+                parsed.rejected + importResult.rejected
+            }
+        GuestListImportReport(importResult.acceptedCount, rejected)
+    }
+}
+
+internal fun GuestListImportReport.toSummary(dryRun: Boolean): String {
+    val prefix = if (dryRun) {
+        "Dry run: $accepted rows would be imported"
+    } else {
+        "Imported $accepted rows"
+    }
+    return if (rejected.isEmpty()) {
+        "$prefix. No errors."
+    } else {
+        "$prefix. Rejected ${rejected.size} rows."
+    }
+}
+
+internal fun GuestListImportReport.toCsv(): String {
+    val builder = StringBuilder()
+    builder.appendLine("accepted_count,rejected_count")
+    builder.appendLine("$accepted,${rejected.size}")
+    if (rejected.isNotEmpty()) {
+        builder.appendLine("line,reason")
+        rejected.forEach { row ->
+            val reason = row.reason.replace("\"", "\"\"")
+            builder.appendLine("${row.line},\"$reason\"")
+        }
+    }
+    return builder.toString()
+}
+
+@Serializable
+private data class GuestListEntryResponse(
+    val id: Long,
+    val listId: Long,
+    val listTitle: String,
+    val clubId: Long,
+    val ownerType: String,
+    val ownerUserId: Long,
+    val fullName: String,
+    val phone: String?,
+    val guestsCount: Int,
+    val notes: String?,
+    val status: String,
+    val listCreatedAt: String,
+)
+
+@Serializable
+private data class GuestListPageResponse(
+    val items: List<GuestListEntryResponse>,
+    val total: Long,
+    val page: Int,
+    val size: Int,
+)
+
+@Serializable
+private data class ImportReportResponse(val accepted: Int, val rejected: List<RejectedRowResponse>)
+
+@Serializable
+private data class RejectedRowResponse(val line: Int, val reason: String)
+
+private data class SearchContext(
+    val filter: GuestListEntrySearch?,
+    val page: Int,
+    val size: Int,
+    val empty: Boolean,
+    val forbidden: Boolean,
+)
+
+private fun ApplicationCall.extractSearch(context: RbacContext): SearchContext {
+    val params = request.queryParameters
+    val page = params.get("page")?.toIntOrNull()?.let { if (it >= 0) it else null } ?: 0
+    val size = params.get("size")?.toIntOrNull()?.let { if (it > 0) it else null } ?: 50
+    val name = params.get("name")?.takeIf { it.isNotBlank() }
+    val phone = params.get("phone")?.takeIf { it.isNotBlank() }
+    val status =
+        params.get("status")?.let {
+            runCatching { GuestListEntryStatus.valueOf(it.uppercase()) }
+                .getOrElse { throw BadRequestException("Invalid status") }
+        }
+    val clubParam = params.get("club")?.toLongOrNull()
+    val from = parseInstant(params.get("from"))
+    val to = parseInstant(params.get("to"))
+
+    val baseFilter =
+        GuestListEntrySearch(
+            nameQuery = name,
+            phoneQuery = phone,
+            status = status,
+            createdFrom = from,
+            createdTo = to,
+        )
+    val globalRoles = setOf(Role.OWNER, Role.GLOBAL_ADMIN, Role.HEAD_MANAGER)
+    val hasGlobal = context.roles.any { it in globalRoles }
+    var forbidden = false
+    val clubIds: Set<Long>? =
+        when {
+            hasGlobal -> clubParam?.let { setOf(it) }
+            Role.PROMOTER in context.roles -> clubParam?.let { setOf(it) }
+            else -> {
+                val allowed = context.clubIds
+                if (clubParam != null && clubParam !in allowed) {
+                    forbidden = true
+                    emptySet()
+                } else if (clubParam != null) {
+                    setOf(clubParam)
+                } else {
+                    allowed
+                }
+            }
+        }
+    val ownerId = if (Role.PROMOTER in context.roles) context.user.id else null
+    val empty = clubIds?.isEmpty() == true
+    val filter =
+        if (empty || forbidden) {
+            null
+        } else {
+            baseFilter.copy(
+                clubIds = clubIds?.takeIf { it.isNotEmpty() },
+                ownerUserId = ownerId,
+            )
+        }
+    return SearchContext(filter, page, size, empty, forbidden)
+}
+
+private fun parseInstant(value: String?): Instant? {
+    if (value.isNullOrBlank()) return null
+    return runCatching { Instant.parse(value) }
+        .getOrElse {
+            val date = runCatching { LocalDate.parse(value) }.getOrElse { throw BadRequestException("Invalid date") }
+            date.atStartOfDay().toInstant(ZoneOffset.UTC)
+        }
+}
+
+private fun GuestListEntryView.toResponse(): GuestListEntryResponse {
+    return GuestListEntryResponse(
+        id = id,
+        listId = listId,
+        listTitle = listTitle,
+        clubId = clubId,
+        ownerType = ownerType.name,
+        ownerUserId = ownerUserId,
+        fullName = fullName,
+        phone = phone,
+        guestsCount = guestsCount,
+        notes = notes,
+        status = status.name,
+        listCreatedAt = listCreatedAt.toString(),
+    )
+}
+
+private fun GuestListImportReport.toResponse(): ImportReportResponse {
+    return ImportReportResponse(
+        accepted = accepted,
+        rejected = rejected.map { RejectedRowResponse(it.line, it.reason) },
+    )
+}
+
+private fun List<GuestListEntryView>.toExportCsv(): String {
+    val builder = StringBuilder()
+    builder.appendLine("entry_id,list_id,club_id,list_title,owner_type,owner_user_id,full_name,phone,guests_count,status,notes,list_created_at")
+    for (item in this) {
+        builder.append(item.id)
+        builder.append(',')
+        builder.append(item.listId)
+        builder.append(',')
+        builder.append(item.clubId)
+        builder.append(',')
+        builder.append(escapeCsv(item.listTitle))
+        builder.append(',')
+        builder.append(item.ownerType.name)
+        builder.append(',')
+        builder.append(item.ownerUserId)
+        builder.append(',')
+        builder.append(escapeCsv(item.fullName))
+        builder.append(',')
+        builder.append(item.phone ?: "")
+        builder.append(',')
+        builder.append(item.guestsCount)
+        builder.append(',')
+        builder.append(item.status.name)
+        builder.append(',')
+        builder.append(escapeCsv(item.notes))
+        builder.append(',')
+        builder.append(item.listCreatedAt.toString())
+        builder.append('\n')
+    }
+    return builder.toString()
+}
+
+private fun escapeCsv(value: String?): String {
+    if (value.isNullOrEmpty()) return ""
+    val escaped = value.replace("\"", "\"\"")
+    return "\"$escaped\""
+}
+
+private fun com.example.bot.security.rbac.RbacContext.canAccess(list: GuestList): Boolean {
+    val globalRoles = setOf(Role.OWNER, Role.GLOBAL_ADMIN, Role.HEAD_MANAGER)
+    if (roles.any { it in globalRoles }) {
+        return true
+    }
+    return when {
+        Role.PROMOTER in roles -> list.ownerType == GuestListOwnerType.PROMOTER && list.ownerUserId == user.id
+        else -> list.clubId in clubIds
+    }
+}
+
+private fun ApplicationCall.wantsCsv(): Boolean {
+    if (request.queryParameters["format"]?.equals("csv", ignoreCase = true) == true) {
+        return true
+    }
+    return request.acceptItems().any { header -> header.value.equals(ContentType.Text.CSV.toString(), ignoreCase = true) }
+}
+
+private fun String?.toBooleanStrictOrNull(): Boolean? {
+    return this?.let {
+        when {
+            it.equals("true", ignoreCase = true) -> true
+            it.equals("false", ignoreCase = true) -> false
+            else -> null
+        }
+    }
+}
+
+private val TSV_CONTENT_TYPE: ContentType = ContentType.parse("text/tab-separated-values")

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/GuestListImportBotHandler.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/GuestListImportBotHandler.kt
@@ -1,0 +1,49 @@
+package com.example.bot.telegram
+
+import com.example.bot.club.GuestListRepository
+import com.example.bot.data.club.GuestListCsvParser
+import com.example.bot.routes.performGuestListImport
+import com.example.bot.routes.toCsv
+import com.example.bot.routes.toSummary
+import com.pengrad.telegrambot.model.Update
+import com.pengrad.telegrambot.request.SendDocument
+import com.pengrad.telegrambot.request.SendMessage
+import com.pengrad.telegrambot.response.BaseResponse
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import kotlin.io.use
+
+/** Handles guest list import interactions for Telegram users. */
+class GuestListImportBotHandler(
+    private val repository: GuestListRepository,
+    private val parser: GuestListCsvParser,
+    private val download: suspend (String) -> InputStream,
+    private val send: suspend (Any) -> BaseResponse,
+) {
+    /** Processes document uploads with captions like `list=42 dry_run`. */
+    suspend fun handle(update: Update) {
+        val message = update.message() ?: return
+        val document = message.document() ?: return
+        val caption = message.caption()?.trim() ?: return
+        val parts = caption.split(Regex("\\s+")).filter { it.isNotBlank() }
+        val listToken = parts.firstOrNull { it.startsWith("list=") } ?: return
+        val listId = listToken.removePrefix("list=").toLongOrNull() ?: return
+        val dryRun = parts.any { it.equals("dry_run", true) || it.equals("dry-run", true) }
+        val chatId = message.chat().id()
+        try {
+            download(document.fileId()).use { stream ->
+                val report = performGuestListImport(repository, parser, listId, stream, dryRun)
+                val summary = report.toSummary(dryRun)
+                send(SendMessage(chatId, summary))
+                if (report.rejected.isNotEmpty()) {
+                    val csv = report.toCsv().toByteArray(StandardCharsets.UTF_8)
+                    val document = SendDocument(chatId, csv).fileName("import_report.csv")
+                    send(document)
+                }
+            }
+        } catch (ex: Throwable) {
+            val reason = ex.message ?: "Import failed"
+            send(SendMessage(chatId, "Ошибка импорта: $reason"))
+        }
+    }
+}

--- a/app-bot/src/test/kotlin/com/example/bot/guestlist/GuestListRoutesTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/guestlist/GuestListRoutesTest.kt
@@ -1,0 +1,389 @@
+package com.example.bot.guestlist
+
+import com.example.bot.club.GuestListOwnerType
+import com.example.bot.club.GuestListRepository
+import com.example.bot.club.GuestListStatus
+import com.example.bot.data.booking.EventsTable
+import com.example.bot.data.club.GuestListCsvParser
+import com.example.bot.data.club.GuestListRepositoryImpl
+import com.example.bot.data.security.Role
+import com.example.bot.plugins.DataSourceHolder
+import com.example.bot.plugins.configureSecurity
+import com.example.bot.routes.guestListRoutes
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.testApplication
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import org.flywaydb.core.Flyway
+import org.h2.jdbcx.JdbcDataSource
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class GuestListRoutesTest : StringSpec({
+    lateinit var dataSource: JdbcDataSource
+    lateinit var database: Database
+    lateinit var repository: GuestListRepository
+    val parser = GuestListCsvParser()
+
+    beforeTest {
+        val setup = prepareDatabase()
+        dataSource = setup.dataSource
+        database = setup.database
+        repository = GuestListRepositoryImpl(database)
+    }
+
+    afterTest {
+        DataSourceHolder.dataSource = null
+    }
+
+    fun Application.testModule() {
+        DataSourceHolder.dataSource = dataSource
+        install(ContentNegotiation) { json() }
+        configureSecurity()
+        guestListRoutes(repository, parser)
+    }
+
+    suspend fun createClub(name: String): Long {
+        return transaction(database) {
+            ClubsTable.insert {
+                it[ClubsTable.name] = name
+                it[timezone] = "Europe/Moscow"
+                it[description] = null
+                it[adminChannelId] = null
+                it[bookingsTopicId] = null
+                it[checkinTopicId] = null
+                it[qaTopicId] = null
+            } get ClubsTable.id
+        }
+    }
+
+    suspend fun createEvent(clubId: Long, title: String): Long {
+        val start = Instant.parse("2024-07-01T18:00:00Z")
+        val end = Instant.parse("2024-07-02T02:00:00Z")
+        return transaction(database) {
+            EventsTable.insert {
+                it[EventsTable.clubId] = clubId
+                it[EventsTable.title] = title
+                it[startAt] = start.atOffset(ZoneOffset.UTC)
+                it[endAt] = end.atOffset(ZoneOffset.UTC)
+            } get EventsTable.id
+        }
+    }
+
+    suspend fun createDomainUser(username: String): Long {
+        return transaction(database) {
+            UsersTable.insert {
+                it[telegramUserId] = null
+                it[UsersTable.username] = username
+                it[displayName] = username
+                it[phone] = null
+            } get UsersTable.id
+        }
+    }
+
+    suspend fun registerRbacUser(telegramId: Long, roles: Set<Role>, clubs: Set<Long>): Long {
+        return transaction(database) {
+            roles.forEach { role ->
+                if (RolesTable.selectAll().none { it[RolesTable.code] == role.name }) {
+                    RolesTable.insert { it[code] = role.name }
+                }
+            }
+            val userId =
+                UsersTable.insert {
+                    it[UsersTable.telegramUserId] = telegramId
+                    it[username] = "user$telegramId"
+                    it[displayName] = "user$telegramId"
+                    it[phone] = null
+                } get UsersTable.id
+            roles.forEach { role ->
+                if (clubs.isEmpty()) {
+                    UserRolesTable.insert {
+                        it[UserRolesTable.userId] = userId
+                        it[roleCode] = role.name
+                        it[scopeType] = "GLOBAL"
+                        it[scopeClubId] = null
+                    }
+                } else {
+                    clubs.forEach { clubId ->
+                        UserRolesTable.insert {
+                            it[UserRolesTable.userId] = userId
+                            it[roleCode] = role.name
+                            it[scopeType] = "CLUB"
+                            it[scopeClubId] = clubId
+                        }
+                    }
+                }
+            }
+            userId
+        }
+    }
+
+    "import dry run returns json report" {
+        val clubId = createClub("Nebula")
+        val eventId = createEvent(clubId, "Launch")
+        val ownerId = createDomainUser("owner1")
+        val list =
+            repository.createList(
+                clubId = clubId,
+                eventId = eventId,
+                ownerType = GuestListOwnerType.MANAGER,
+                ownerUserId = ownerId,
+                title = "VIP",
+                capacity = 50,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        registerRbacUser(telegramId = 100L, roles = setOf(Role.MANAGER), clubs = setOf(clubId))
+
+        testApplication {
+            application { testModule() }
+            val response =
+                client.post("/api/guest-lists/${list.id}/import?dry_run=true") {
+                    header("X-Telegram-Id", "100")
+                    contentType(ContentType.Text.CSV)
+                    setBody("name,phone,guests_count,notes\nAlice,+123456789,2,VIP\n")
+                }
+            response.status shouldBe HttpStatusCode.OK
+            val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            json["accepted"]!!.toString() shouldBe "1"
+            json["rejected"]!!.jsonArray.shouldHaveSize(0)
+            repository.listEntries(list.id, page = 0, size = 10) shouldHaveSize 0
+        }
+    }
+
+    "commit import persists and returns csv" {
+        val clubId = createClub("Orion")
+        val eventId = createEvent(clubId, "Opening")
+        val ownerId = createDomainUser("owner2")
+        val list =
+            repository.createList(
+                clubId = clubId,
+                eventId = eventId,
+                ownerType = GuestListOwnerType.MANAGER,
+                ownerUserId = ownerId,
+                title = "Friends",
+                capacity = 30,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        registerRbacUser(telegramId = 200L, roles = setOf(Role.MANAGER), clubs = setOf(clubId))
+
+        testApplication {
+            application { testModule() }
+            val response =
+                client.post("/api/guest-lists/${list.id}/import") {
+                    header("X-Telegram-Id", "200")
+                    header(HttpHeaders.Accept, ContentType.Text.CSV.toString())
+                    contentType(ContentType.Text.CSV)
+                    setBody("name,phone,guests_count,notes\nBob,+123456700,3,\n")
+                }
+            response.status shouldBe HttpStatusCode.OK
+            response.headers[HttpHeaders.ContentType]!!.startsWith("text/csv") shouldBe true
+            repository.listEntries(list.id, page = 0, size = 10) shouldHaveSize 1
+        }
+    }
+
+    "manager sees only own club" {
+        val clubA = createClub("Nova")
+        val clubB = createClub("Pulse")
+        val eventA = createEvent(clubA, "Night A")
+        val eventB = createEvent(clubB, "Night B")
+        val ownerA = createDomainUser("managerA")
+        val ownerB = createDomainUser("managerB")
+        val listA =
+            repository.createList(
+                clubId = clubA,
+                eventId = eventA,
+                ownerType = GuestListOwnerType.MANAGER,
+                ownerUserId = ownerA,
+                title = "List A",
+                capacity = 20,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        val listB =
+            repository.createList(
+                clubId = clubB,
+                eventId = eventB,
+                ownerType = GuestListOwnerType.MANAGER,
+                ownerUserId = ownerB,
+                title = "List B",
+                capacity = 20,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        repository.addEntry(listA.id, "Alice", "+100", 2, null)
+        repository.addEntry(listB.id, "Clare", "+200", 1, null)
+        registerRbacUser(telegramId = 300L, roles = setOf(Role.MANAGER), clubs = setOf(clubA))
+
+        testApplication {
+            application { testModule() }
+            val response = client.get("/api/guest-lists") { header("X-Telegram-Id", "300") }
+            response.status shouldBe HttpStatusCode.OK
+            val items = Json.parseToJsonElement(response.bodyAsText()).jsonObject["items"]!!.jsonArray
+            items.shouldHaveSize(1)
+            items.first().jsonObject["clubId"].toString() shouldBe clubA.toString()
+
+            val forbidden = client.get("/api/guest-lists?club=$clubB") { header("X-Telegram-Id", "300") }
+            forbidden.status shouldBe HttpStatusCode.Forbidden
+        }
+    }
+
+    "promoter filtered by owner" {
+        val club = createClub("Pulse")
+        val event = createEvent(club, "Promo")
+        val promoterUserId = registerRbacUser(telegramId = 400L, roles = setOf(Role.PROMOTER), clubs = setOf(club))
+        val managerOwner = createDomainUser("manager")
+        val promoterList =
+            repository.createList(
+                clubId = club,
+                eventId = event,
+                ownerType = GuestListOwnerType.PROMOTER,
+                ownerUserId = promoterUserId,
+                title = "Promo",
+                capacity = 15,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        val managerList =
+            repository.createList(
+                clubId = club,
+                eventId = event,
+                ownerType = GuestListOwnerType.MANAGER,
+                ownerUserId = managerOwner,
+                title = "Manager",
+                capacity = 15,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        repository.addEntry(promoterList.id, "Promo Guest", "+111", 1, null)
+        repository.addEntry(managerList.id, "Club Guest", "+222", 1, null)
+
+        testApplication {
+            application { testModule() }
+            val response = client.get("/api/guest-lists") { header("X-Telegram-Id", "400") }
+            response.status shouldBe HttpStatusCode.OK
+            val items = Json.parseToJsonElement(response.bodyAsText()).jsonObject["items"]!!.jsonArray
+            items.shouldHaveSize(1)
+            items.first().jsonObject["listId"].toString() shouldBe promoterList.id.toString()
+        }
+    }
+
+    "head manager export returns csv" {
+        val club = createClub("Zenith")
+        val event = createEvent(club, "Gala")
+        val owner = createDomainUser("head")
+        val list =
+            repository.createList(
+                clubId = club,
+                eventId = event,
+                ownerType = GuestListOwnerType.MANAGER,
+                ownerUserId = owner,
+                title = "Gala",
+                capacity = 40,
+                arrivalWindowStart = null,
+                arrivalWindowEnd = null,
+                status = GuestListStatus.ACTIVE,
+            )
+        repository.addEntry(list.id, "Guest One", "+500", 2, "VIP")
+        registerRbacUser(telegramId = 500L, roles = setOf(Role.HEAD_MANAGER), clubs = emptySet())
+
+        testApplication {
+            application { testModule() }
+            val response = client.get("/api/guest-lists/export") { header("X-Telegram-Id", "500") }
+            response.status shouldBe HttpStatusCode.OK
+            response.headers[HttpHeaders.ContentType]!!.startsWith("text/csv") shouldBe true
+            response.bodyAsText().contains("Guest One") shouldBe true
+        }
+    }
+})
+
+private data class DbSetup(val dataSource: JdbcDataSource, val database: Database)
+
+private fun prepareDatabase(): DbSetup {
+    val dbName = "guestlists_${UUID.randomUUID()}"
+    val dataSource =
+        JdbcDataSource().apply {
+            setURL("jdbc:h2:mem:$dbName;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1")
+            user = "sa"
+            password = ""
+        }
+    Flyway
+        .configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/common", "classpath:db/migration/h2")
+        .target("9")
+        .load()
+        .migrate()
+    val database = Database.connect(dataSource)
+    transaction(database) {
+        listOf("action", "result").forEach { column ->
+            exec("""ALTER TABLE audit_log ALTER COLUMN $column RENAME TO "$column"""")
+        }
+        exec("ALTER TABLE audit_log ALTER COLUMN resource_id DROP NOT NULL")
+    }
+    return DbSetup(dataSource, database)
+}
+
+private object ClubsTable : Table("clubs") {
+    val id = long("id").autoIncrement()
+    val name = text("name")
+    val description = text("description").nullable()
+    val timezone = text("timezone")
+    val adminChannelId = long("admin_channel_id").nullable()
+    val bookingsTopicId = integer("bookings_topic_id").nullable()
+    val checkinTopicId = integer("checkin_topic_id").nullable()
+    val qaTopicId = integer("qa_topic_id").nullable()
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object UsersTable : Table("users") {
+    val id = long("id").autoIncrement()
+    val telegramUserId = long("telegram_user_id").nullable()
+    val username = text("username").nullable()
+    val displayName = text("display_name").nullable()
+    val phone = text("phone_e164").nullable()
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object RolesTable : Table("roles") {
+    val code = text("code")
+    override val primaryKey = PrimaryKey(code)
+}
+
+private object UserRolesTable : Table("user_roles") {
+    val id = long("id").autoIncrement()
+    val userId = long("user_id")
+    val roleCode = text("role_code")
+    val scopeType = text("scope_type")
+    val scopeClubId = long("scope_club_id").nullable()
+    override val primaryKey = PrimaryKey(id)
+}

--- a/core-data/src/main/resources/db/migration/h2/V9__club_indexes.sql
+++ b/core-data/src/main/resources/db/migration/h2/V9__club_indexes.sql
@@ -1,20 +1,29 @@
+DROP INDEX IF EXISTS idx_guest_list_entries_list_status;
+
 ALTER TABLE guest_lists
     ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
-ALTER TABLE guest_list_entries ALTER COLUMN status SET DEFAULT 'PLANNED';
-ALTER TABLE guest_list_entries ALTER COLUMN status SET CHECK (status IN ('PLANNED','CHECKED_IN','NO_SHOW'));
+ALTER TABLE guest_list_entries ALTER COLUMN status RENAME TO status_old;
+
+ALTER TABLE guest_list_entries
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'PLANNED';
 
 UPDATE guest_list_entries
 SET status =
-    CASE status
+    CASE status_old
         WHEN 'ARRIVED' THEN 'CHECKED_IN'
         WHEN 'NO_SHOW' THEN 'NO_SHOW'
         WHEN 'APPROVED' THEN 'PLANNED'
         WHEN 'INVITED' THEN 'PLANNED'
         WHEN 'DENIED' THEN 'NO_SHOW'
         WHEN 'LATE' THEN 'NO_SHOW'
-        ELSE status
+        ELSE status_old
     END;
+
+ALTER TABLE guest_list_entries DROP COLUMN status_old;
+
+ALTER TABLE guest_list_entries
+    ADD CONSTRAINT chk_guest_list_entries_status CHECK (status IN ('PLANNED','CHECKED_IN','NO_SHOW'));
 
 UPDATE guest_list_entries
 SET checked_in_at = NULL,

--- a/core-domain/src/main/kotlin/com/example/bot/club/GuestListRepository.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/club/GuestListRepository.kt
@@ -47,6 +47,12 @@ interface GuestListRepository {
     ): List<GuestListEntry>
 
     suspend fun bulkImport(listId: Long, rows: List<ParsedGuest>, dryRun: Boolean): BulkImportResult
+
+    suspend fun searchEntries(
+        filter: GuestListEntrySearch,
+        page: Int,
+        size: Int,
+    ): GuestListEntryPage
 }
 
 enum class GuestListOwnerType {
@@ -103,3 +109,31 @@ data class ParsedGuest(
 data class RejectedRow(val line: Int, val reason: String)
 
 data class BulkImportResult(val acceptedCount: Int, val rejected: List<RejectedRow>)
+
+data class GuestListEntrySearch(
+    val clubIds: Set<Long>? = null,
+    val listIds: Set<Long>? = null,
+    val ownerUserId: Long? = null,
+    val nameQuery: String? = null,
+    val phoneQuery: String? = null,
+    val status: GuestListEntryStatus? = null,
+    val createdFrom: Instant? = null,
+    val createdTo: Instant? = null,
+)
+
+data class GuestListEntryView(
+    val id: Long,
+    val listId: Long,
+    val listTitle: String,
+    val clubId: Long,
+    val ownerType: GuestListOwnerType,
+    val ownerUserId: Long,
+    val fullName: String,
+    val phone: String?,
+    val guestsCount: Int,
+    val notes: String?,
+    val status: GuestListEntryStatus,
+    val listCreatedAt: Instant,
+)
+
+data class GuestListEntryPage(val items: List<GuestListEntryView>, val total: Long)


### PR DESCRIPTION
## Summary
- extend the guest list repository contract with search DTOs, implement the Exposed query, and adjust the H2 migration so the new filters work on in-memory tests
- expose the RBAC context to Ktor routes and add guest list REST endpoints for searching, exporting CSV, and performing CSV/TSV imports with dry-run reports
- update the Telegram guest list import handler to reuse the shared helpers and add route integration tests that exercise import, export, and role-based access filters

## Testing
- ./gradlew --console=plain core-data:test app-bot:test

------
https://chatgpt.com/codex/tasks/task_e_68ceeb165bb08321892f865d03ea6b96