### PR TITLE
Implement promoter template booking notifications

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/di/BookingModules.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/di/BookingModules.kt
@@ -8,6 +8,7 @@ import com.example.bot.data.booking.core.OutboxRepository
 import com.example.bot.data.promo.BookingTemplateRepositoryImpl
 import com.example.bot.data.promo.PromoAttributionRepositoryImpl
 import com.example.bot.data.promo.PromoLinkRepositoryImpl
+import com.example.bot.data.notifications.NotificationsOutboxRepository
 import com.example.bot.data.security.ExposedUserRepository
 import com.example.bot.data.security.ExposedUserRoleRepository
 import com.example.bot.plugins.DataSourceHolder
@@ -32,6 +33,7 @@ val bookingModule = module {
     single { BookingRepository(get()) }
     single { BookingHoldRepository(get()) }
     single { OutboxRepository(get()) }
+    single { NotificationsOutboxRepository(get()) }
     single { AuditLogRepository(get()) }
     single { PromoLinkRepositoryImpl(get()) }
     single { PromoAttributionRepositoryImpl(get()) }
@@ -41,7 +43,7 @@ val bookingModule = module {
     single<PromoAttributionStore> { InMemoryPromoAttributionStore() }
     single { PromoAttributionService(get(), get(), get(), get(), get()) }
     single<PromoAttributionCoordinator> { get<PromoAttributionService>() }
-    single { BookingTemplateService(get(), get(), get(), get()) }
+    single { BookingTemplateService(get(), get(), get(), get(), get()) }
     single<SendPort> { DummySendPort }
     single { BookingService(get(), get(), get(), get(), get()) }
     single { OutboxWorker(get(), get()) }

--- a/app-bot/src/test/kotlin/com/example/bot/promo/BookingTemplateIdempotencyKeyTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/promo/BookingTemplateIdempotencyKeyTest.kt
@@ -1,0 +1,31 @@
+package com.example.bot.promo
+
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class BookingTemplateIdempotencyKeyTest {
+    private val slot = Instant.parse("2025-05-01T18:00:00Z")
+
+    @Test
+    fun `same input yields deterministic key`() {
+        val first = templateIdempotencyKey(12L, 34L, slot, 56L)
+        val second = templateIdempotencyKey(12L, 34L, slot, 56L)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `changing any attribute alters key`() {
+        val base = templateIdempotencyKey(12L, 34L, slot, 56L)
+        val differentTemplate = templateIdempotencyKey(99L, 34L, slot, 56L)
+        val differentPromoter = templateIdempotencyKey(12L, 77L, slot, 56L)
+        val differentSlot = templateIdempotencyKey(12L, 34L, slot.plusSeconds(3_600), 56L)
+        val differentTable = templateIdempotencyKey(12L, 34L, slot, 57L)
+
+        assertNotEquals(base, differentTemplate)
+        assertNotEquals(base, differentPromoter)
+        assertNotEquals(base, differentSlot)
+        assertNotEquals(base, differentTable)
+    }
+}

--- a/app-bot/src/test/kotlin/com/example/bot/telegram/BookingTemplateOttPayloadTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/telegram/BookingTemplateOttPayloadTest.kt
@@ -1,7 +1,8 @@
 package com.example.bot.telegram
 
-import com.example.bot.telegram.ott.TemplateOttPayload.Booking
 import com.example.bot.telegram.ott.CallbackTokenService
+import com.example.bot.telegram.ott.TemplateOttPayload.Booking
+import com.example.bot.telegram.ott.TemplateOttPayload.Selection
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -30,5 +31,15 @@ class BookingTemplateOttPayloadTest {
 
         val replay = tokenService.consume(token)
         assertNull(replay)
+    }
+
+    @Test
+    fun `selection payload fits callback limit`() {
+        val payload = Selection(templateId = Long.MAX_VALUE)
+        val token = tokenService.issueToken(payload)
+        assertTrue(token.length <= 64)
+
+        val decoded = tokenService.consume(token)
+        assertEquals(payload, decoded)
     }
 }

--- a/core-data/src/main/kotlin/com/example/bot/data/notifications/Repositories.kt
+++ b/core-data/src/main/kotlin/com/example/bot/data/notifications/Repositories.kt
@@ -168,6 +168,38 @@ data class OutboxRecord(
 )
 
 class NotificationsOutboxRepository(private val db: Database) {
+    suspend fun enqueue(
+        kind: String,
+        payload: JsonElement,
+        recipientType: String,
+        recipientId: Long,
+        clubId: Long? = null,
+        targetChatId: Long = 0,
+        messageThreadId: Int? = null,
+        method: String = "EVENT",
+        priority: Int = 100,
+        dedupKey: String? = null,
+        campaignId: Long? = null,
+        language: String? = null,
+    ): Long {
+        return newSuspendedTransaction(db = db) {
+            NotificationsOutboxTable.insert { row ->
+                row[NotificationsOutboxTable.clubId] = clubId
+                row[NotificationsOutboxTable.targetChatId] = targetChatId
+                row[NotificationsOutboxTable.messageThreadId] = messageThreadId
+                row[NotificationsOutboxTable.kind] = kind
+                row[NotificationsOutboxTable.payload] = payload
+                row[NotificationsOutboxTable.recipientType] = recipientType
+                row[NotificationsOutboxTable.recipientId] = recipientId
+                row[NotificationsOutboxTable.dedupKey] = dedupKey
+                row[NotificationsOutboxTable.priority] = priority
+                row[NotificationsOutboxTable.campaignId] = campaignId
+                row[NotificationsOutboxTable.method] = method
+                row[NotificationsOutboxTable.language] = language
+            }[NotificationsOutboxTable.id]
+        }
+    }
+
     suspend fun insert(record: OutboxRecord) {
         return newSuspendedTransaction(db = db) {
             NotificationsOutboxTable.insert {


### PR DESCRIPTION
## Summary
- add pagination helpers, deterministic idempotency, and notifications outbox publishing to the booking template service
- register the notifications outbox repository in DI and expose a helper for enqueuing promo template events
- extend integration and unit tests to cover OTT payload limits, idempotency keys, and promo template booking notifications

## Testing
- `./gradlew clean build test detekt --console=plain`
- `./gradlew clean build test detekt -PrunIT=true --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68cf01b77a1483218e5a9fcc72a5c7f8