### PR TITLE
feat(bot): add guest selection flow with booking finalization

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/Application.kt
@@ -77,7 +77,7 @@ fun Application.module() {
             single<ClubRepository> { ExposedClubRepository(get()) }
             single<CoroutineScope> { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
             single<ChatUiSessionStore> { InMemoryChatUiSessionStore() }
-            single { MenuCallbacksHandler(get(), get(), get(), get(), get(), get(), get()) }
+            single { MenuCallbacksHandler(get(), get(), get(), get(), get(), get(), get(), get()) }
             single { CallbackQueryHandler(get(), get(), get()) }
         }
     install(Koin) {

--- a/app-bot/src/main/kotlin/com/example/bot/i18n/BotTexts.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/i18n/BotTexts.kt
@@ -3,6 +3,7 @@ package com.example.bot.i18n
 /**
  * Localized bot texts used across guest flow.
  */
+@Suppress("TooManyFunctions")
 class BotTexts {
     /**
      * Returns greeting text based on [lang]. Defaults to Russian.
@@ -30,6 +31,39 @@ class BotTexts {
      * Prompt shown before table selection.
      */
     fun chooseTable(lang: String?): String = if (lang.isEnglish()) "Choose a table:" else "Выберите стол:"
+
+    fun chooseGuests(lang: String?) =
+        if (lang.isEnglish()) "Choose number of guests:" else "Выберите количество гостей:"
+
+    fun buttonExpired(lang: String?) =
+        if (lang.isEnglish()) {
+            "The button has expired, please refresh the screen."
+        } else {
+            "Кнопка устарела, обновите экран."
+        }
+
+    fun tableTaken(lang: String?) =
+        if (lang.isEnglish()) {
+            "This table is already taken. Please choose another one."
+        } else {
+            "Стол уже занят. Выберите другой, пожалуйста."
+        }
+
+    fun tooManyRequests(lang: String?) =
+        if (lang.isEnglish()) {
+            "Too many requests. Please try again."
+        } else {
+            "Слишком много запросов. Попробуйте ещё раз."
+        }
+
+    fun holdExpired(lang: String?) =
+        if (lang.isEnglish()) {
+            "Hold expired. Please try again."
+        } else {
+            "Пауза истекла. Попробуйте снова."
+        }
+
+    fun bookingConfirmedTitle(lang: String?) = if (lang.isEnglish()) "Booking confirmed ✅" else "Бронь подтверждена ✅"
 
     fun sessionExpired(lang: String?) =
         if (lang.isEnglish()) {

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/Keyboards.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/Keyboards.kt
@@ -103,7 +103,7 @@ class Keyboards(private val texts: BotTexts) {
         val rows = mutableListOf<Array<InlineKeyboardButton>>()
         var row = mutableListOf<InlineKeyboardButton>()
         for (i in 1..capacity) {
-            row += InlineKeyboardButton(i.toString()).callbackData("g:${encode(i)}")
+            row += InlineKeyboardButton(i.toString()).callbackData(encode(i).ensureGuestPrefix())
             if (row.size == GUESTS_PER_ROW) {
                 rows += row.toTypedArray()
                 row = mutableListOf()
@@ -116,7 +116,12 @@ class Keyboards(private val texts: BotTexts) {
 
 private const val GUESTS_PER_ROW = 4
 private const val TABLE_PREFIX = "tbl:"
+private const val GUEST_PREFIX = "g:"
 
 private fun String.ensureTablePrefix(): String {
     return if (startsWith(TABLE_PREFIX)) this else TABLE_PREFIX + this
+}
+
+private fun String.ensureGuestPrefix(): String {
+    return if (startsWith(GUEST_PREFIX)) this else GUEST_PREFIX + this
 }

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/tokens/GuestsSelectCodec.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/tokens/GuestsSelectCodec.kt
@@ -1,0 +1,92 @@
+package com.example.bot.telegram.tokens
+
+import java.time.Duration
+import java.time.Instant
+
+object GuestsSelectCodec {
+    private const val RADIX = 36
+    private const val SEPARATOR = '.'
+    private const val PREFIX = "g:"
+    private const val EXPECTED_PARTS = 5
+    private const val CLUB_INDEX = 0
+    private const val START_INDEX = 1
+    private const val END_INDEX = 2
+    private const val TABLE_INDEX = 3
+    private const val GUESTS_INDEX = 4
+    private const val MIN_ID = 0L
+    private const val MIN_GUESTS = 1
+    private const val MAX_GUESTS = Int.MAX_VALUE
+
+    fun encode(
+        clubId: Long,
+        startUtc: Instant,
+        endUtc: Instant,
+        tableId: Long,
+        guests: Int,
+    ): String {
+        require(clubId >= MIN_ID) { "clubId must be non-negative" }
+        require(tableId >= MIN_ID) { "tableId must be non-negative" }
+        require(guests >= MIN_GUESTS) { "guests must be positive" }
+        val normalizedEnd = normalizeEnd(startUtc, endUtc)
+        val payload =
+            listOf(
+                clubId.toString(RADIX),
+                startUtc.epochSecond.toString(RADIX),
+                normalizedEnd.epochSecond.toString(RADIX),
+                tableId.toString(RADIX),
+                guests.toString(RADIX),
+            ).joinToString(SEPARATOR.toString())
+        return PREFIX + payload
+    }
+
+    fun decode(token: String): DecodedGuests? =
+        runCatching {
+            require(token.startsWith(PREFIX))
+            val payload = token.substring(PREFIX.length)
+            val parts = payload.split(SEPARATOR)
+            require(parts.size == EXPECTED_PARTS)
+            require(parts.none { it.isEmpty() })
+
+            val clubId = parts[CLUB_INDEX].toLongOrNull(RADIX) ?: throw IllegalArgumentException("Not a number")
+            val startSec = parts[START_INDEX].toLongOrNull(RADIX) ?: throw IllegalArgumentException("Not a number")
+            val endSec = parts[END_INDEX].toLongOrNull(RADIX) ?: throw IllegalArgumentException("Not a number")
+            val tableId = parts[TABLE_INDEX].toLongOrNull(RADIX) ?: throw IllegalArgumentException("Not a number")
+            val guestsLong = parts[GUESTS_INDEX].toLongOrNull(RADIX) ?: throw IllegalArgumentException("Not a number")
+
+            require(clubId >= MIN_ID)
+            require(tableId >= MIN_ID)
+            require(startSec >= MIN_ID)
+            require(endSec >= MIN_ID)
+            require(guestsLong >= MIN_GUESTS)
+            require(guestsLong <= MAX_GUESTS)
+
+            DecodedGuests(
+                clubId = clubId,
+                startUtc = Instant.ofEpochSecond(startSec),
+                endUtc = Instant.ofEpochSecond(endSec),
+                tableId = tableId,
+                guests = guestsLong.toInt(),
+            )
+        }.getOrNull()
+
+    private fun normalizeEnd(
+        startUtc: Instant,
+        endUtc: Instant,
+    ): Instant {
+        return if (endUtc.isAfter(startUtc)) {
+            endUtc
+        } else {
+            startUtc.plus(DEFAULT_DURATION)
+        }
+    }
+
+    private val DEFAULT_DURATION: Duration = Duration.ofHours(8)
+}
+
+data class DecodedGuests(
+    val clubId: Long,
+    val startUtc: Instant,
+    val endUtc: Instant,
+    val tableId: Long,
+    val guests: Int,
+)

--- a/app-bot/src/test/kotlin/com/example/bot/telegram/tokens/GuestsSelectCodecTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/telegram/tokens/GuestsSelectCodecTest.kt
@@ -1,0 +1,65 @@
+package com.example.bot.telegram.tokens
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GuestsSelectCodecTest {
+    @Test
+    fun `encode decode round trip`() {
+        val start = Instant.parse("2024-04-01T18:00:00Z")
+        val end = start.plusSeconds(6 * 3600)
+        val token =
+            GuestsSelectCodec.encode(
+                clubId = 1234L,
+                startUtc = start,
+                endUtc = end,
+                tableId = 55L,
+                guests = 4,
+            )
+        assertTrue(token.length <= 64)
+        val decoded = GuestsSelectCodec.decode(token)
+        assertNotNull(decoded)
+        assertEquals(1234L, decoded.clubId)
+        assertEquals(start, decoded.startUtc)
+        assertEquals(end, decoded.endUtc)
+        assertEquals(55L, decoded.tableId)
+        assertEquals(4, decoded.guests)
+    }
+
+    @Test
+    fun `encode normalizes zero end`() {
+        val start = Instant.parse("2024-04-01T18:00:00Z")
+        val token =
+            GuestsSelectCodec.encode(
+                clubId = 1L,
+                startUtc = start,
+                endUtc = start,
+                tableId = 2L,
+                guests = 2,
+            )
+        val decoded = GuestsSelectCodec.decode(token)
+        assertNotNull(decoded)
+        assertTrue(decoded.endUtc.isAfter(start))
+    }
+
+    @Test
+    fun `decode rejects malformed tokens`() {
+        assertNull(GuestsSelectCodec.decode(""))
+        assertNull(GuestsSelectCodec.decode("g:"))
+        assertNull(GuestsSelectCodec.decode("g:a.b.c.d"))
+        assertNull(GuestsSelectCodec.decode("g:a.b.c.d.e.f"))
+    }
+
+    @Test
+    fun `decode rejects invalid numbers`() {
+        assertNull(GuestsSelectCodec.decode("g:-1.a.a.a.a"))
+        assertNull(GuestsSelectCodec.decode("g:a.-1.a.a.a"))
+        assertNull(GuestsSelectCodec.decode("g:a.a.-1.a.a"))
+        assertNull(GuestsSelectCodec.decode("g:a.a.a.-1.a"))
+        assertNull(GuestsSelectCodec.decode("g:a.a.a.a.-1"))
+    }
+}


### PR DESCRIPTION
## Summary
- add GuestsSelectCodec and coverage to encode/decode guest selection payloads
- show a guest count keyboard after table selection and drive hold → confirm → finalize
- localize new guest flow strings, adjust callback keyboard prefixes, and wire booking service into the handler

## Testing
- ./gradlew clean build detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d3d871e728832189ffa9b3ffd9b86b