### PR TITLE
Add UI booking metrics and instrument Telegram menu flow

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/metrics/AppMetricsBinder.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/metrics/AppMetricsBinder.kt
@@ -34,5 +34,8 @@ object AppMetricsBinder {
         // DB metrics (20.2)
         registry.gauge("db.tx.retries.atomic", DbMetrics.txRetries)
         registry.gauge("db.query.slow.count.atomic", DbMetrics.slowQueryCount)
+
+        // UI booking metrics
+        UiBookingMetrics.bind(registry)
     }
 }

--- a/app-bot/src/main/kotlin/com/example/bot/metrics/UiBookingMetrics.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/metrics/UiBookingMetrics.kt
@@ -1,0 +1,69 @@
+package com.example.bot.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+object UiBookingMetrics {
+    val menuClicks = AtomicLong(0)
+    val nightsRendered = AtomicLong(0)
+    val tablesRendered = AtomicLong(0)
+    val pagesRendered = AtomicLong(0)
+    val tableChosen = AtomicLong(0)
+    val guestsChosen = AtomicLong(0)
+    val bookingSuccess = AtomicLong(0)
+    val bookingError = AtomicLong(0)
+
+    @PublishedApi
+    @Volatile
+    internal var listTablesTimer: Timer? = null
+
+    @PublishedApi
+    @Volatile
+    internal var bookingTotalTimer: Timer? = null
+    private const val PERCENTILE_MEDIAN = 0.5
+    private const val PERCENTILE_95 = 0.95
+    private const val PERCENTILE_99 = 0.99
+
+    fun bind(registry: MeterRegistry) {
+        registry.gauge("ui.menu.clicks.atomic", menuClicks)
+        registry.gauge("ui.nights.rendered.atomic", nightsRendered)
+        registry.gauge("ui.tables.rendered.atomic", tablesRendered)
+        registry.gauge("ui.tables.pages.atomic", pagesRendered)
+        registry.gauge("ui.table.chosen.atomic", tableChosen)
+        registry.gauge("ui.guests.chosen.atomic", guestsChosen)
+        registry.gauge("ui.booking.success.atomic", bookingSuccess)
+        registry.gauge("ui.booking.error.atomic", bookingError)
+
+        listTablesTimer =
+            Timer.builder("ui.tables.fetch.duration.ms")
+                .publishPercentiles(PERCENTILE_MEDIAN, PERCENTILE_95, PERCENTILE_99)
+                .description("AvailabilityService.listFreeTables duration")
+                .register(registry)
+
+        bookingTotalTimer =
+            Timer.builder("ui.booking.total.duration.ms")
+                .publishPercentiles(PERCENTILE_MEDIAN, PERCENTILE_95, PERCENTILE_99)
+                .description("End-to-end booking flow from guests selection")
+                .register(registry)
+    }
+
+    inline fun <T> timeListTables(block: () -> T): T {
+        val start = System.nanoTime()
+        return try {
+            block()
+        } finally {
+            listTablesTimer?.record(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+        }
+    }
+
+    inline fun <T> timeBookingTotal(block: () -> T): T {
+        val start = System.nanoTime()
+        return try {
+            block()
+        } finally {
+            bookingTotalTimer?.record(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+        }
+    }
+}

--- a/app-bot/src/test/kotlin/com/example/bot/metrics/UiBookingMetricsTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/metrics/UiBookingMetricsTest.kt
@@ -1,0 +1,65 @@
+package com.example.bot.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class UiBookingMetricsTest {
+    private lateinit var registry: SimpleMeterRegistry
+
+    @BeforeEach
+    fun setUp() {
+        UiBookingMetrics.menuClicks.set(0)
+        UiBookingMetrics.nightsRendered.set(0)
+        UiBookingMetrics.tablesRendered.set(0)
+        UiBookingMetrics.pagesRendered.set(0)
+        UiBookingMetrics.tableChosen.set(0)
+        UiBookingMetrics.guestsChosen.set(0)
+        UiBookingMetrics.bookingSuccess.set(0)
+        UiBookingMetrics.bookingError.set(0)
+        registry = SimpleMeterRegistry()
+        UiBookingMetrics.bind(registry)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        registry.close()
+    }
+
+    @Test
+    fun `counters are exposed via gauges`() {
+        UiBookingMetrics.menuClicks.incrementAndGet()
+        UiBookingMetrics.nightsRendered.incrementAndGet()
+        UiBookingMetrics.tablesRendered.incrementAndGet()
+        UiBookingMetrics.pagesRendered.incrementAndGet()
+        UiBookingMetrics.tableChosen.incrementAndGet()
+        UiBookingMetrics.guestsChosen.incrementAndGet()
+        UiBookingMetrics.bookingSuccess.incrementAndGet()
+        UiBookingMetrics.bookingError.incrementAndGet()
+
+        assertEquals(1.0, registry.get("ui.menu.clicks.atomic").gauge().value())
+        assertEquals(1.0, registry.get("ui.nights.rendered.atomic").gauge().value())
+        assertEquals(1.0, registry.get("ui.tables.rendered.atomic").gauge().value())
+        assertEquals(1.0, registry.get("ui.tables.pages.atomic").gauge().value())
+        assertEquals(1.0, registry.get("ui.table.chosen.atomic").gauge().value())
+        assertEquals(1.0, registry.get("ui.guests.chosen.atomic").gauge().value())
+        assertEquals(1.0, registry.get("ui.booking.success.atomic").gauge().value())
+        assertEquals(1.0, registry.get("ui.booking.error.atomic").gauge().value())
+    }
+
+    @Test
+    fun `timers record durations`() {
+        UiBookingMetrics.timeListTables { Thread.sleep(10) }
+        UiBookingMetrics.timeBookingTotal { Thread.sleep(5) }
+
+        val listTimer = registry.get("ui.tables.fetch.duration.ms").timer()
+        val totalTimer = registry.get("ui.booking.total.duration.ms").timer()
+
+        assertTrue(listTimer.totalTime(TimeUnit.MILLISECONDS) > 0.0)
+        assertTrue(totalTimer.totalTime(TimeUnit.MILLISECONDS) > 0.0)
+    }
+}


### PR DESCRIPTION
## Summary
- add UiBookingMetrics to expose UI booking counters and timers and cover them with unit tests
- bind the new metrics in AppMetricsBinder to make them visible via the Prometheus endpoint
- instrument MenuCallbacksHandler with Micrometer timings, counter updates, and safer logging/MDC for the booking flow

## Testing
- ./gradlew clean build detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d3f94613048321b91a6efb65f0dda1