### PR TITLE
Route guest callbacks through menu handler

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/telegram/ott/CallbackTokenService.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/ott/CallbackTokenService.kt
@@ -56,9 +56,6 @@ class CallbackQueryHandler(
     }
 
     private fun isMenuCallback(data: String): Boolean {
-        if (data == NOOP_CALLBACK) {
-            return true
-        }
         return MENU_PREFIXES.any { prefix -> data.startsWith(prefix) }
     }
 
@@ -77,5 +74,14 @@ class CallbackQueryHandler(
     }
 }
 
-private val MENU_PREFIXES = listOf("menu:", "club:", "night:", "tbl:", "pg:")
 private const val NOOP_CALLBACK = "noop"
+private val MENU_PREFIXES =
+    listOf(
+        "menu:",
+        "club:",
+        "night:",
+        "tbl:",
+        "pg:",
+        "g:",
+        NOOP_CALLBACK,
+    )

--- a/app-bot/src/test/kotlin/com/example/bot/telegram/ott/CallbackQueryHandlerTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/telegram/ott/CallbackQueryHandlerTest.kt
@@ -1,0 +1,45 @@
+package com.example.bot.telegram.ott
+
+import com.example.bot.telegram.MenuCallbacksHandler
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.CallbackQuery
+import com.pengrad.telegrambot.model.Update
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifySequence
+import org.junit.jupiter.api.Test
+
+class CallbackQueryHandlerTest {
+    private val bot: TelegramBot = mockk(relaxed = true)
+    private val tokenService: CallbackTokenService = mockk(relaxed = true)
+    private val menuCallbacksHandler: MenuCallbacksHandler = mockk(relaxed = true)
+
+    private val handler = CallbackQueryHandler(bot, tokenService, menuCallbacksHandler)
+
+    @Test
+    fun `routes night table and guests callbacks to menu handler`() {
+        val nightUpdate = updateWithData("night:42")
+        val tableUpdate = updateWithData("tbl:42:11")
+        val guestsUpdate = updateWithData("g:42:11:4")
+
+        handler.handle(nightUpdate)
+        handler.handle(tableUpdate)
+        handler.handle(guestsUpdate)
+
+        verifySequence {
+            menuCallbacksHandler.handle(nightUpdate)
+            menuCallbacksHandler.handle(tableUpdate)
+            menuCallbacksHandler.handle(guestsUpdate)
+        }
+        verify(exactly = 0) { tokenService.consume(any()) }
+    }
+
+    private fun updateWithData(data: String): Update {
+        val callbackQuery = mockk<CallbackQuery>()
+        every { callbackQuery.data() } returns data
+        return mockk {
+            every { callbackQuery() } returns callbackQuery
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Menu callback routing includes the `g:` payload so guest selection is handled before OTT token processing
- simplify `isMenuCallback` to rely on the unified prefix list including `noop`
- add a unit test that exercises the night → table → guest callback flow and verifies routing through `MenuCallbacksHandler`

## Testing
- ./gradlew clean build detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d40a0a56608321847f38c520f594be