### PR TITLE
Rename UI booking metric gauges

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/metrics/UiBookingMetrics.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/metrics/UiBookingMetrics.kt
@@ -27,14 +27,14 @@ object UiBookingMetrics {
     private const val PERCENTILE_99 = 0.99
 
     fun bind(registry: MeterRegistry) {
-        registry.gauge("ui.menu.clicks.atomic", menuClicks)
-        registry.gauge("ui.nights.rendered.atomic", nightsRendered)
-        registry.gauge("ui.tables.rendered.atomic", tablesRendered)
-        registry.gauge("ui.tables.pages.atomic", pagesRendered)
-        registry.gauge("ui.table.chosen.atomic", tableChosen)
-        registry.gauge("ui.guests.chosen.atomic", guestsChosen)
-        registry.gauge("ui.booking.success.atomic", bookingSuccess)
-        registry.gauge("ui.booking.error.atomic", bookingError)
+        registry.gauge("ui.menu.clicks", menuClicks)
+        registry.gauge("ui.nights.rendered", nightsRendered)
+        registry.gauge("ui.tables.rendered", tablesRendered)
+        registry.gauge("ui.tables.pages", pagesRendered)
+        registry.gauge("ui.table.chosen", tableChosen)
+        registry.gauge("ui.guests.chosen", guestsChosen)
+        registry.gauge("ui.booking.success", bookingSuccess)
+        registry.gauge("ui.booking.error", bookingError)
 
         listTablesTimer =
             Timer.builder("ui.tables.fetch.duration.ms")

--- a/app-bot/src/test/kotlin/com/example/bot/metrics/UiBookingMetricsTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/metrics/UiBookingMetricsTest.kt
@@ -41,14 +41,14 @@ class UiBookingMetricsTest {
         UiBookingMetrics.bookingSuccess.incrementAndGet()
         UiBookingMetrics.bookingError.incrementAndGet()
 
-        assertEquals(1.0, registry.get("ui.menu.clicks.atomic").gauge().value())
-        assertEquals(1.0, registry.get("ui.nights.rendered.atomic").gauge().value())
-        assertEquals(1.0, registry.get("ui.tables.rendered.atomic").gauge().value())
-        assertEquals(1.0, registry.get("ui.tables.pages.atomic").gauge().value())
-        assertEquals(1.0, registry.get("ui.table.chosen.atomic").gauge().value())
-        assertEquals(1.0, registry.get("ui.guests.chosen.atomic").gauge().value())
-        assertEquals(1.0, registry.get("ui.booking.success.atomic").gauge().value())
-        assertEquals(1.0, registry.get("ui.booking.error.atomic").gauge().value())
+        assertEquals(1.0, registry.get("ui.menu.clicks").gauge().value())
+        assertEquals(1.0, registry.get("ui.nights.rendered").gauge().value())
+        assertEquals(1.0, registry.get("ui.tables.rendered").gauge().value())
+        assertEquals(1.0, registry.get("ui.tables.pages").gauge().value())
+        assertEquals(1.0, registry.get("ui.table.chosen").gauge().value())
+        assertEquals(1.0, registry.get("ui.guests.chosen").gauge().value())
+        assertEquals(1.0, registry.get("ui.booking.success").gauge().value())
+        assertEquals(1.0, registry.get("ui.booking.error").gauge().value())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- rename the UI booking gauges to the DoD metric names without the legacy `.atomic` suffix
- update `UiBookingMetricsTest` expectations to assert the new metric identifiers

## Testing
- ./gradlew :app-bot:test --rerun-tasks --tests com.example.bot.metrics.UiBookingMetricsTest --console plain

------
https://chatgpt.com/codex/tasks/task_e_68d4323031b88321b5800d54c1508b30