### PR TITLE
Add InitData verification and authentication plugin for Telegram WebApp

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/plugins/SecurityPlugins.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/plugins/SecurityPlugins.kt
@@ -5,6 +5,7 @@ import com.example.bot.data.security.ExposedUserRepository
 import com.example.bot.data.security.ExposedUserRoleRepository
 import com.example.bot.security.auth.TelegramPrincipal
 import com.example.bot.security.rbac.RbacPlugin
+import com.example.bot.webapp.InitDataPrincipalKey
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -29,8 +30,13 @@ fun Application.configureSecurity() {
         this.userRoleRepository = userRoleRepository
         this.auditLogRepository = auditLogRepository
         principalExtractor = { call ->
-            call.request.header("X-Telegram-Id")?.toLongOrNull()?.let { id ->
-                TelegramPrincipal(id, call.request.header("X-Telegram-Username"))
+            if (call.attributes.contains(InitDataPrincipalKey)) {
+                val principal = call.attributes[InitDataPrincipalKey]
+                TelegramPrincipal(principal.userId, principal.username)
+            } else {
+                call.request.header("X-Telegram-Id")?.toLongOrNull()?.let { id ->
+                    TelegramPrincipal(id, call.request.header("X-Telegram-Username"))
+                }
             }
         }
     }

--- a/app-bot/src/main/kotlin/com/example/bot/routes/SecuredRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/SecuredRoutes.kt
@@ -5,8 +5,10 @@ import com.example.bot.data.security.Role
 import com.example.bot.security.rbac.ClubScope
 import com.example.bot.security.rbac.authorize
 import com.example.bot.security.rbac.clubScoped
+import com.example.bot.webapp.InitDataAuthPlugin
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
+import io.ktor.server.application.install
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -28,12 +30,21 @@ fun Application.securedRoutes(bookingService: BookingService) {
             authorize(Role.CLUB_ADMIN, Role.MANAGER, Role.ENTRY_MANAGER) {
                 clubScoped(ClubScope.Own) {
                     get("/bookings") { call.respondText("bookings") }
-                    post("/checkin/scan") { call.respondText("scan") }
                 }
             }
             authorize(Role.PROMOTER, Role.CLUB_ADMIN, Role.MANAGER, Role.GUEST) {
                 clubScoped(ClubScope.Own) {
                     post("/tables/{tableId}/booking") { call.respondText("booked") }
+                }
+            }
+        }
+        route("/api/clubs/{clubId}/checkin") {
+            install(InitDataAuthPlugin) {
+                botTokenProvider = { System.getenv("TELEGRAM_BOT_TOKEN") ?: error("TELEGRAM_BOT_TOKEN missing") }
+            }
+            authorize(Role.CLUB_ADMIN, Role.MANAGER, Role.ENTRY_MANAGER) {
+                clubScoped(ClubScope.Own) {
+                    post("/scan") { call.respondText("scan") }
                 }
             }
         }

--- a/app-bot/src/main/kotlin/com/example/bot/webapp/InitDataAuthPlugin.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/webapp/InitDataAuthPlugin.kt
@@ -1,0 +1,62 @@
+package com.example.bot.webapp
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.response.respond
+import io.ktor.util.AttributeKey
+import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.time.Duration
+
+private const val MAX_HEADER_LENGTH = 8192
+
+data class TelegramPrincipal(
+    val userId: Long,
+    val username: String?,
+    val firstName: String?,
+    val lastName: String?,
+)
+
+class InitDataAuthConfig {
+    lateinit var botTokenProvider: () -> String
+    var maxAge: Duration = Duration.ofHours(24)
+    var clock: Clock = Clock.systemUTC()
+    var headerName: String = "X-Telegram-Init-Data"
+
+    internal fun validate() {
+        check(::botTokenProvider.isInitialized) { "botTokenProvider must be provided" }
+    }
+}
+
+val InitDataPrincipalKey: AttributeKey<TelegramPrincipal> = AttributeKey("webapp.principal")
+
+val InitDataAuthPlugin =
+    createApplicationPlugin("InitDataAuthPlugin", ::InitDataAuthConfig) {
+        pluginConfig.validate()
+        val logger = LoggerFactory.getLogger("InitDataAuth")
+
+        onCall { call ->
+            val header = call.request.headers[pluginConfig.headerName]
+            if (header == null || header.length > MAX_HEADER_LENGTH) {
+                logger.warn("initData header missing or too large")
+                call.respond(HttpStatusCode.Unauthorized)
+                return@onCall
+            }
+            val botToken = pluginConfig.botTokenProvider.invoke()
+            val verified =
+                WebAppInitDataVerifier.verify(header, botToken, pluginConfig.maxAge, pluginConfig.clock)
+            if (verified == null) {
+                logger.warn("initData verification failed")
+                call.respond(HttpStatusCode.Unauthorized)
+                return@onCall
+            }
+            val principal =
+                TelegramPrincipal(
+                    userId = verified.userId,
+                    username = verified.username,
+                    firstName = verified.firstName,
+                    lastName = verified.lastName,
+                )
+            call.attributes.put(InitDataPrincipalKey, principal)
+        }
+    }

--- a/app-bot/src/main/kotlin/com/example/bot/webapp/WebAppInitDataVerifier.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/webapp/WebAppInitDataVerifier.kt
@@ -1,0 +1,210 @@
+package com.example.bot.webapp
+
+import io.ktor.http.decodeURLPart
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.nio.charset.StandardCharsets
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+private const val MAX_INIT_DATA_LENGTH = 8192
+private const val HEX_RADIX = 16
+private const val HALF_BYTE_SHIFT = 4
+private const val FUTURE_TOLERANCE_SECONDS = 60L
+private const val HEX_PAIR_LENGTH = 2
+private val DEFAULT_MAX_AGE: Duration = Duration.ofHours(24)
+
+@Serializable
+private data class TelegramUserPayload(
+    val id: Long,
+    val username: String? = null,
+    @SerialName("first_name") val firstName: String? = null,
+    @SerialName("last_name") val lastName: String? = null,
+)
+
+private val json = Json { ignoreUnknownKeys = true }
+
+private fun hmacSha256(
+    data: ByteArray,
+    key: ByteArray,
+): ByteArray {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(key, "HmacSHA256"))
+    return mac.doFinal(data)
+}
+
+private fun constantTimeEquals(
+    first: ByteArray,
+    second: ByteArray,
+): Boolean {
+    if (first.size != second.size) {
+        return false
+    }
+    var result = 0
+    for (index in first.indices) {
+        result = result or (first[index].toInt() xor second[index].toInt())
+    }
+    return result == 0
+}
+
+private fun hexToBytes(hex: String): ByteArray? {
+    if (hex.length % HEX_PAIR_LENGTH != 0) {
+        return null
+    }
+    val bytes = ByteArray(hex.length / HEX_PAIR_LENGTH)
+    var invalid = false
+    for (index in bytes.indices) {
+        val first = Character.digit(hex[index * HEX_PAIR_LENGTH], HEX_RADIX)
+        val second = Character.digit(hex[index * HEX_PAIR_LENGTH + 1], HEX_RADIX)
+        if (first == -1 || second == -1) {
+            invalid = true
+            break
+        }
+        bytes[index] = ((first shl HALF_BYTE_SHIFT) + second).toByte()
+    }
+    return if (invalid) null else bytes
+}
+
+private fun buildDataCheckString(parameters: Map<String, String>): String {
+    return parameters
+        .toSortedMap()
+        .entries
+        .joinToString("\n") { (key, value) -> "$key=$value" }
+}
+
+private fun decodeSegment(segment: String): Pair<String, String>? {
+    val delimiterIndex = segment.indexOf('=')
+    if (delimiterIndex <= 0) {
+        return null
+    }
+    val keyEncoded = segment.substring(0, delimiterIndex)
+    val valueEncoded = segment.substring(delimiterIndex + 1)
+    val key = runCatching { keyEncoded.decodeURLPart() }.getOrNull()
+    val value = runCatching { valueEncoded.decodeURLPart() }.getOrNull()
+    return if (key == null || value == null) {
+        null
+    } else {
+        key to value
+    }
+}
+
+private fun parseQuery(initData: String): Map<String, String>? {
+    if (initData.isEmpty()) {
+        return emptyMap()
+    }
+    val result = mutableMapOf<String, String>()
+    var invalid = false
+    for (segment in initData.split('&')) {
+        if (segment.isNotEmpty()) {
+            val decoded = decodeSegment(segment)
+            if (decoded == null) {
+                invalid = true
+            } else {
+                result[decoded.first] = decoded.second
+            }
+            if (invalid) {
+                break
+            }
+        }
+    }
+    return if (invalid) null else result
+}
+
+private fun parseUser(payload: String?): TelegramUserPayload? {
+    if (payload.isNullOrBlank()) {
+        return null
+    }
+    return runCatching { json.decodeFromString(TelegramUserPayload.serializer(), payload) }.getOrNull()
+}
+
+private fun isExpired(
+    authDate: Instant,
+    clock: Clock,
+    maxAge: Duration,
+): Boolean {
+    val now = clock.instant()
+    return authDate.isBefore(now.minus(maxAge)) || authDate.isAfter(now.plusSeconds(FUTURE_TOLERANCE_SECONDS))
+}
+
+private fun String.toInstantOrNull(): Instant? {
+    val epochSeconds = this.toLongOrNull() ?: return null
+    return runCatching { Instant.ofEpochSecond(epochSeconds) }.getOrNull()
+}
+
+private fun secretKey(botToken: String): ByteArray {
+    return hmacSha256(
+        "WebAppData".toByteArray(StandardCharsets.UTF_8),
+        botToken.toByteArray(StandardCharsets.UTF_8),
+    )
+}
+
+object WebAppInitDataVerifier {
+    fun verify(
+        initData: String,
+        botToken: String,
+        maxAge: Duration = DEFAULT_MAX_AGE,
+        clock: Clock = Clock.systemUTC(),
+    ): VerifiedInitData? {
+        if (initData.length > MAX_INIT_DATA_LENGTH) {
+            return null
+        }
+        return buildVerification(initData, botToken, maxAge, clock)
+    }
+
+    private fun buildVerification(
+        initData: String,
+        botToken: String,
+        maxAge: Duration,
+        clock: Clock,
+    ): VerifiedInitData? {
+        val parameters = parseQuery(initData) ?: return null
+        val mutableParameters = parameters.toMutableMap()
+        val hashValue = mutableParameters.remove("hash")
+        var valid = true
+        if (hashValue.isNullOrBlank() || mutableParameters.isEmpty()) {
+            valid = false
+        }
+        val dataCheckString = buildDataCheckString(mutableParameters)
+        val secret = secretKey(botToken)
+        val calculatedHash = hmacSha256(dataCheckString.toByteArray(StandardCharsets.UTF_8), secret)
+        val providedHash = hashValue?.let { hexToBytes(it.lowercase()) }
+        val macMatches = providedHash?.let { constantTimeEquals(calculatedHash, it) } ?: false
+        if (!macMatches) {
+            valid = false
+        }
+        val authDateString = mutableParameters["auth_date"]
+        val authDate = authDateString?.toInstantOrNull()
+        if (authDate == null || isExpired(authDate, clock, maxAge)) {
+            valid = false
+        }
+        val userPayload = parseUser(mutableParameters["user"])
+        if (userPayload == null) {
+            valid = false
+        }
+        return if (!valid || authDate == null || userPayload == null) {
+            null
+        } else {
+            VerifiedInitData(
+                userId = userPayload.id,
+                username = userPayload.username,
+                firstName = userPayload.firstName,
+                lastName = userPayload.lastName,
+                authDate = authDate,
+                raw = mutableParameters.toMap(),
+            )
+        }
+    }
+}
+
+data class VerifiedInitData(
+    val userId: Long,
+    val username: String?,
+    val firstName: String?,
+    val lastName: String?,
+    val authDate: Instant,
+    val raw: Map<String, String>,
+)

--- a/app-bot/src/test/kotlin/com/example/bot/webapp/InitDataAuthPluginTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/webapp/InitDataAuthPluginTest.kt
@@ -1,0 +1,61 @@
+package com.example.bot.webapp
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+
+class InitDataAuthPluginTest {
+    @Test
+    fun `responds with 200 for valid init data`() =
+        testApplication {
+            val currentEpochSeconds = System.currentTimeMillis() / 1000L
+            val validHeader =
+                WebAppInitDataTestHelper.createInitData(
+                    TEST_BOT_TOKEN,
+                    linkedMapOf(
+                        "user" to WebAppInitDataTestHelper.encodeUser(id = 7L, username = "agent"),
+                        "auth_date" to currentEpochSeconds.toString(),
+                    ),
+                )
+            application {
+                routing {
+                    route("/webapp-test") {
+                        install(InitDataAuthPlugin) {
+                            botTokenProvider = { TEST_BOT_TOKEN }
+                            maxAge = Duration.ofHours(24)
+                            clock = Clock.systemUTC()
+                        }
+                        get {
+                            if (call.attributes.contains(InitDataPrincipalKey)) {
+                                call.respond(HttpStatusCode.OK)
+                            } else {
+                                call.respond(HttpStatusCode.Unauthorized)
+                            }
+                        }
+                    }
+                }
+            }
+            val success = client.get("/webapp-test") { header("X-Telegram-Init-Data", validHeader) }
+            success.status shouldBe HttpStatusCode.OK
+
+            val missing = client.get("/webapp-test")
+            missing.status shouldBe HttpStatusCode.Unauthorized
+
+            val invalid =
+                client.get("/webapp-test") {
+                    header("X-Telegram-Init-Data", validHeader.replace("a", "b"))
+                }
+            invalid.status shouldBe HttpStatusCode.Unauthorized
+        }
+}

--- a/app-bot/src/test/kotlin/com/example/bot/webapp/WebAppInitDataVerifierTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/webapp/WebAppInitDataVerifierTest.kt
@@ -1,0 +1,170 @@
+package com.example.bot.webapp
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+internal const val TEST_BOT_TOKEN = "123:ABC"
+
+internal object WebAppInitDataTestHelper {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class TestUser(
+        val id: Long,
+        val username: String? = null,
+        @SerialName("first_name") val firstName: String? = null,
+        @SerialName("last_name") val lastName: String? = null,
+    )
+
+    fun encodeUser(
+        id: Long,
+        username: String? = null,
+        firstName: String? = null,
+        lastName: String? = null,
+    ): String {
+        return json.encodeToString(TestUser.serializer(), TestUser(id, username, firstName, lastName))
+    }
+
+    fun createInitData(
+        botToken: String,
+        rawParams: Map<String, String>,
+    ): String {
+        val secret =
+            hmacSha256(
+                "WebAppData".toByteArray(StandardCharsets.UTF_8),
+                botToken.toByteArray(StandardCharsets.UTF_8),
+            )
+        val dataCheck = rawParams.toSortedMap().entries.joinToString("\n") { (key, value) -> "$key=$value" }
+        val hash = hmacSha256(dataCheck.toByteArray(StandardCharsets.UTF_8), secret).toHex()
+        val encodedPairs =
+            rawParams.entries.joinToString("&") { (key, value) ->
+                "${encode(key)}=${encode(value)}"
+            }
+        return "$encodedPairs&hash=$hash"
+    }
+
+    private fun hmacSha256(
+        data: ByteArray,
+        key: ByteArray,
+    ): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+
+    private fun ByteArray.toHex(): String {
+        val chars = CharArray(size * 2)
+        for (index in indices) {
+            val value = this[index].toInt() and 0xFF
+            chars[index * 2] = Character.forDigit(value shr 4, 16)
+            chars[index * 2 + 1] = Character.forDigit(value and 0x0F, 16)
+        }
+        return String(chars)
+    }
+
+    private fun encode(value: String): String {
+        return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8)
+    }
+}
+
+class WebAppInitDataVerifierTest {
+    private val clock: Clock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC)
+
+    @Test
+    fun `returns verified data when signature valid`() {
+        val authDate = clock.instant().minusSeconds(60).epochSecond.toString()
+        val parameters =
+            linkedMapOf(
+                "user" to
+                    WebAppInitDataTestHelper.encodeUser(
+                        id = 42L,
+                        username = "neo",
+                        firstName = "Thomas",
+                        lastName = "Anderson",
+                    ),
+                "auth_date" to authDate,
+                "query_id" to "AAA",
+            )
+        val initData =
+            WebAppInitDataTestHelper.createInitData(TEST_BOT_TOKEN, parameters)
+
+        val verified = WebAppInitDataVerifier.verify(initData, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+
+        assertNotNull(verified)
+        verified!!
+        assertEquals(42L, verified.userId)
+        assertEquals("neo", verified.username)
+        assertEquals("Thomas", verified.firstName)
+        assertEquals("Anderson", verified.lastName)
+        assertEquals(Instant.ofEpochSecond(authDate.toLong()), verified.authDate)
+        assertEquals(parameters, verified.raw)
+    }
+
+    @Test
+    fun `returns null when hash invalid`() {
+        val parameters =
+            linkedMapOf(
+                "user" to WebAppInitDataTestHelper.encodeUser(id = 1L),
+                "auth_date" to clock.instant().epochSecond.toString(),
+            )
+        val initData =
+            WebAppInitDataTestHelper.createInitData(TEST_BOT_TOKEN, parameters)
+        val tampered = initData.replaceRange(initData.length - 1, initData.length, "0")
+
+        val verified = WebAppInitDataVerifier.verify(tampered, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+
+        assertNull(verified)
+    }
+
+    @Test
+    fun `returns null when hash missing`() {
+        val parameters =
+            linkedMapOf(
+                "user" to WebAppInitDataTestHelper.encodeUser(id = 5L),
+                "auth_date" to clock.instant().epochSecond.toString(),
+            )
+        val encodedPairs =
+            parameters.entries.joinToString("&") { (key, value) ->
+                "$key=${java.net.URLEncoder.encode(value, StandardCharsets.UTF_8)}"
+            }
+        val verified = WebAppInitDataVerifier.verify(encodedPairs, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+
+        assertNull(verified)
+    }
+
+    @Test
+    fun `returns null when auth date expired`() {
+        val expiredAuthDate = clock.instant().minus(Duration.ofDays(2)).epochSecond.toString()
+        val parameters =
+            linkedMapOf(
+                "user" to WebAppInitDataTestHelper.encodeUser(id = 10L),
+                "auth_date" to expiredAuthDate,
+            )
+        val initData =
+            WebAppInitDataTestHelper.createInitData(TEST_BOT_TOKEN, parameters)
+
+        val verified = WebAppInitDataVerifier.verify(initData, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+
+        assertNull(verified)
+    }
+
+    @Test
+    fun `returns null when header too long`() {
+        val longString = "x".repeat(8205)
+        val verified = WebAppInitDataVerifier.verify(longString, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+
+        assertNull(verified)
+    }
+}


### PR DESCRIPTION
## Summary
- implement a secure WebApp init data verifier with HMAC validation, auth_date TTL checks, and Telegram user parsing
- add an InitDataAuth Ktor plugin that authenticates Telegram Web App requests and populates the principal for RBAC
- configure RBAC to consume the new principal and protect the check-in route with the plugin
- cover the verifier and plugin with targeted unit and integration tests

## Testing
- ./gradlew clean build detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d51803fafc8321b414ad32d3904191