### PR TITLE
Add deterministic coverage for WebApp init data and QR codec

### DIFF
--- a/app-bot/src/test/kotlin/com/example/bot/webapp/InitDataAuthPluginTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/webapp/InitDataAuthPluginTest.kt
@@ -1,6 +1,5 @@
 package com.example.bot.webapp
 
-import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.HttpStatusCode
@@ -11,30 +10,126 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.assertEquals
+
+private fun hmacSha256(
+    key: ByteArray,
+    data: ByteArray,
+): ByteArray {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(key, "HmacSHA256"))
+    return mac.doFinal(data)
+}
+
+private fun hexLower(bytes: ByteArray): String {
+    val builder = StringBuilder(bytes.size * 2)
+    for (byte in bytes) {
+        val value = byte.toInt() and 0xFF
+        builder.append(Character.forDigit(value ushr 4, 16))
+        builder.append(Character.forDigit(value and 0x0F, 16))
+    }
+    return builder.toString()
+}
+
+private fun buildDataCheckString(params: Map<String, String>): String {
+    return params
+        .filterKeys { it != "hash" }
+        .toSortedMap()
+        .entries
+        .joinToString("\n") { (key, value) -> "$key=$value" }
+}
+
+private fun buildInitData(
+    botToken: String,
+    map: Map<String, String>,
+): String {
+    val withoutHash = map.filterKeys { it != "hash" }
+    val secretKey =
+        hmacSha256(
+            botToken.toByteArray(StandardCharsets.UTF_8),
+            "WebAppData".toByteArray(StandardCharsets.UTF_8),
+        )
+    val dataCheckString = buildDataCheckString(withoutHash)
+    val hashHex = hexLower(hmacSha256(secretKey, dataCheckString.toByteArray(StandardCharsets.UTF_8)))
+    val builder = StringBuilder()
+    var first = true
+    for ((key, value) in map) {
+        if (key == "hash") {
+            continue
+        }
+        if (!first) {
+            builder.append('&')
+        } else {
+            first = false
+        }
+        builder.append(URLEncoder.encode(key, StandardCharsets.UTF_8))
+        builder.append('=')
+        builder.append(URLEncoder.encode(value, StandardCharsets.UTF_8))
+    }
+    if (!first) {
+        builder.append('&')
+    }
+    builder.append("hash=")
+    builder.append(hashHex)
+    return builder.toString()
+}
 
 class InitDataAuthPluginTest {
+    private val botToken = TEST_BOT_TOKEN
+    private val fixedNow = Instant.parse("2025-09-25T12:00:00Z")
+    private val clock: Clock = Clock.fixed(fixedNow, ZoneOffset.UTC)
+    private val json = Json { encodeDefaults = false }
+
+    @Serializable
+    private data class TestUser(
+        val id: Long,
+        val username: String,
+        @SerialName("first_name") val firstName: String,
+        @SerialName("last_name") val lastName: String,
+    )
+
+    private fun validInitData(): String {
+        val authDate = fixedNow.epochSecond - 120
+        val userJson =
+            json.encodeToString(
+                TestUser.serializer(),
+                TestUser(
+                    id = 123456789,
+                    username = "entry_mgr",
+                    firstName = "Alex",
+                    lastName = "S",
+                ),
+            )
+        val map =
+            linkedMapOf(
+                "user" to userJson,
+                "auth_date" to authDate.toString(),
+            )
+        return buildInitData(botToken, map)
+    }
+
     @Test
-    fun `responds with 200 for valid init data`() =
+    fun `plugin authorizes valid init data`() =
         testApplication {
-            val currentEpochSeconds = System.currentTimeMillis() / 1000L
-            val validHeader =
-                WebAppInitDataTestHelper.createInitData(
-                    TEST_BOT_TOKEN,
-                    linkedMapOf(
-                        "user" to WebAppInitDataTestHelper.encodeUser(id = 7L, username = "agent"),
-                        "auth_date" to currentEpochSeconds.toString(),
-                    ),
-                )
             application {
                 routing {
-                    route("/webapp-test") {
+                    route("/t") {
                         install(InitDataAuthPlugin) {
-                            botTokenProvider = { TEST_BOT_TOKEN }
+                            botTokenProvider = { botToken }
                             maxAge = Duration.ofHours(24)
-                            clock = Clock.systemUTC()
+                            this.clock = this@InitDataAuthPluginTest.clock
                         }
                         get {
                             if (call.attributes.contains(InitDataPrincipalKey)) {
@@ -46,16 +141,24 @@ class InitDataAuthPluginTest {
                     }
                 }
             }
-            val success = client.get("/webapp-test") { header("X-Telegram-Init-Data", validHeader) }
-            success.status shouldBe HttpStatusCode.OK
 
-            val missing = client.get("/webapp-test")
-            missing.status shouldBe HttpStatusCode.Unauthorized
+            val header = validInitData()
+            val success =
+                client.get("/t") {
+                    header("X-Telegram-Init-Data", header)
+                }
+            assertEquals(HttpStatusCode.OK, success.status)
+
+            val missing = client.get("/t")
+            assertEquals(HttpStatusCode.Unauthorized, missing.status)
 
             val invalid =
-                client.get("/webapp-test") {
-                    header("X-Telegram-Init-Data", validHeader.replace("a", "b"))
+                client.get("/t") {
+                    header(
+                        "X-Telegram-Init-Data",
+                        header.replaceRange(header.length - 1, header.length, "0"),
+                    )
                 }
-            invalid.status shouldBe HttpStatusCode.Unauthorized
+            assertEquals(HttpStatusCode.Unauthorized, invalid.status)
         }
 }

--- a/app-bot/src/test/kotlin/com/example/bot/webapp/WebAppInitDataTestHelper.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/webapp/WebAppInitDataTestHelper.kt
@@ -1,0 +1,74 @@
+package com.example.bot.webapp
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+internal const val TEST_BOT_TOKEN: String = "111111:TEST_BOT_TOKEN"
+
+internal object WebAppInitDataTestHelper {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class TelegramUser(
+        val id: Long,
+        val username: String? = null,
+        @SerialName("first_name") val firstName: String? = null,
+        @SerialName("last_name") val lastName: String? = null,
+    )
+
+    fun encodeUser(
+        id: Long,
+        username: String? = null,
+        firstName: String? = null,
+        lastName: String? = null,
+    ): String {
+        return json.encodeToString(TelegramUser.serializer(), TelegramUser(id, username, firstName, lastName))
+    }
+
+    fun createInitData(
+        botToken: String,
+        rawParams: Map<String, String>,
+    ): String {
+        val secretKey =
+            hmacSha256(
+                botToken.toByteArray(StandardCharsets.UTF_8),
+                "WebAppData".toByteArray(StandardCharsets.UTF_8),
+            )
+        val dataCheckString =
+            rawParams
+                .filterKeys { it != "hash" }
+                .toSortedMap()
+                .entries
+                .joinToString("\n") { (key, value) -> "$key=$value" }
+        val hash = hexLower(hmacSha256(secretKey, dataCheckString.toByteArray(StandardCharsets.UTF_8)))
+        val encodedPairs =
+            rawParams.entries.joinToString("&") { (key, value) ->
+                "${URLEncoder.encode(key, StandardCharsets.UTF_8)}=${URLEncoder.encode(value, StandardCharsets.UTF_8)}"
+            }
+        return "$encodedPairs&hash=$hash"
+    }
+
+    private fun hmacSha256(
+        key: ByteArray,
+        data: ByteArray,
+    ): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+
+    private fun hexLower(bytes: ByteArray): String {
+        val builder = StringBuilder(bytes.size * 2)
+        for (byte in bytes) {
+            val value = byte.toInt() and 0xFF
+            builder.append(Character.forDigit(value ushr 4, 16))
+            builder.append(Character.forDigit(value and 0x0F, 16))
+        }
+        return builder.toString()
+    }
+}

--- a/app-bot/src/test/kotlin/com/example/bot/webapp/WebAppInitDataVerifierTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/webapp/WebAppInitDataVerifierTest.kt
@@ -3,10 +3,8 @@ package com.example.bot.webapp
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Clock
 import java.time.Duration
@@ -14,157 +12,273 @@ import java.time.Instant
 import java.time.ZoneOffset
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
-internal const val TEST_BOT_TOKEN = "123:ABC"
+private fun hmacSha256(
+    key: ByteArray,
+    data: ByteArray,
+): ByteArray {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(key, "HmacSHA256"))
+    return mac.doFinal(data)
+}
 
-internal object WebAppInitDataTestHelper {
-    private val json = Json { ignoreUnknownKeys = true }
+private fun hexLower(bytes: ByteArray): String {
+    val builder = StringBuilder(bytes.size * 2)
+    for (byte in bytes) {
+        val value = byte.toInt() and 0xFF
+        builder.append(Character.forDigit(value ushr 4, 16))
+        builder.append(Character.forDigit(value and 0x0F, 16))
+    }
+    return builder.toString()
+}
+
+private fun buildDataCheckString(params: Map<String, String>): String {
+    return params
+        .filterKeys { it != "hash" }
+        .toSortedMap()
+        .entries
+        .joinToString("\n") { (key, value) -> "$key=$value" }
+}
+
+private fun buildInitData(
+    botToken: String,
+    map: Map<String, String>,
+): String {
+    val withoutHash = map.filterKeys { it != "hash" }
+    val secretKey =
+        hmacSha256(
+            botToken.toByteArray(StandardCharsets.UTF_8),
+            "WebAppData".toByteArray(StandardCharsets.UTF_8),
+        )
+    val dataCheckString = buildDataCheckString(withoutHash)
+    val hashHex = hexLower(hmacSha256(secretKey, dataCheckString.toByteArray(StandardCharsets.UTF_8)))
+    val builder = StringBuilder()
+    var first = true
+    for ((key, value) in map) {
+        if (key == "hash") {
+            continue
+        }
+        if (!first) {
+            builder.append('&')
+        } else {
+            first = false
+        }
+        builder.append(URLEncoder.encode(key, StandardCharsets.UTF_8))
+        builder.append('=')
+        builder.append(URLEncoder.encode(value, StandardCharsets.UTF_8))
+    }
+    if (!first) {
+        builder.append('&')
+    }
+    builder.append("hash=")
+    builder.append(hashHex)
+    return builder.toString()
+}
+
+class WebAppInitDataVerifierTest {
+    private val fixedNow = Instant.parse("2025-09-25T12:00:00Z")
+    private val clock: Clock = Clock.fixed(fixedNow, ZoneOffset.UTC)
+    private val maxAge = Duration.ofHours(24)
+    private val botToken = TEST_BOT_TOKEN
+    private val json = Json { encodeDefaults = false }
 
     @Serializable
     private data class TestUser(
         val id: Long,
-        val username: String? = null,
-        @SerialName("first_name") val firstName: String? = null,
-        @SerialName("last_name") val lastName: String? = null,
+        val username: String,
+        @SerialName("first_name") val firstName: String,
+        @SerialName("last_name") val lastName: String,
     )
 
-    fun encodeUser(
-        id: Long,
-        username: String? = null,
-        firstName: String? = null,
-        lastName: String? = null,
-    ): String {
-        return json.encodeToString(TestUser.serializer(), TestUser(id, username, firstName, lastName))
-    }
+    private val userJson: String =
+        json.encodeToString(
+            TestUser.serializer(),
+            TestUser(
+                id = 123456789,
+                username = "entry_mgr",
+                firstName = "Alex",
+                lastName = "S",
+            ),
+        )
 
-    fun createInitData(
-        botToken: String,
-        rawParams: Map<String, String>,
-    ): String {
-        val secret =
-            hmacSha256(
-                "WebAppData".toByteArray(StandardCharsets.UTF_8),
-                botToken.toByteArray(StandardCharsets.UTF_8),
-            )
-        val dataCheck = rawParams.toSortedMap().entries.joinToString("\n") { (key, value) -> "$key=$value" }
-        val hash = hmacSha256(dataCheck.toByteArray(StandardCharsets.UTF_8), secret).toHex()
-        val encodedPairs =
-            rawParams.entries.joinToString("&") { (key, value) ->
-                "${encode(key)}=${encode(value)}"
-            }
-        return "$encodedPairs&hash=$hash"
-    }
-
-    private fun hmacSha256(
-        data: ByteArray,
-        key: ByteArray,
-    ): ByteArray {
-        val mac = Mac.getInstance("HmacSHA256")
-        mac.init(SecretKeySpec(key, "HmacSHA256"))
-        return mac.doFinal(data)
-    }
-
-    private fun ByteArray.toHex(): String {
-        val chars = CharArray(size * 2)
-        for (index in indices) {
-            val value = this[index].toInt() and 0xFF
-            chars[index * 2] = Character.forDigit(value shr 4, 16)
-            chars[index * 2 + 1] = Character.forDigit(value and 0x0F, 16)
-        }
-        return String(chars)
-    }
-
-    private fun encode(value: String): String {
-        return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8)
-    }
-}
-
-class WebAppInitDataVerifierTest {
-    private val clock: Clock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC)
+    private val authDateEpoch: Long = fixedNow.epochSecond - 3600
 
     @Test
-    fun `returns verified data when signature valid`() {
-        val authDate = clock.instant().minusSeconds(60).epochSecond.toString()
-        val parameters =
+    fun `happy path returns verified data`() {
+        val map =
             linkedMapOf(
-                "user" to
-                    WebAppInitDataTestHelper.encodeUser(
-                        id = 42L,
-                        username = "neo",
-                        firstName = "Thomas",
-                        lastName = "Anderson",
-                    ),
-                "auth_date" to authDate,
-                "query_id" to "AAA",
+                "user" to userJson,
+                "auth_date" to authDateEpoch.toString(),
+                "query_id" to "Q-42",
             )
-        val initData =
-            WebAppInitDataTestHelper.createInitData(TEST_BOT_TOKEN, parameters)
+        val initData = buildInitData(botToken, map)
 
-        val verified = WebAppInitDataVerifier.verify(initData, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+        val verified = WebAppInitDataVerifier.verify(initData, botToken, maxAge, clock)
 
         assertNotNull(verified)
-        verified!!
-        assertEquals(42L, verified.userId)
-        assertEquals("neo", verified.username)
-        assertEquals("Thomas", verified.firstName)
-        assertEquals("Anderson", verified.lastName)
-        assertEquals(Instant.ofEpochSecond(authDate.toLong()), verified.authDate)
-        assertEquals(parameters, verified.raw)
+        assertEquals(123456789, verified!!.userId)
+        assertEquals("entry_mgr", verified.username)
+        assertEquals("Alex", verified.firstName)
+        assertEquals("S", verified.lastName)
+        assertEquals(Instant.ofEpochSecond(authDateEpoch), verified.authDate)
+        assertTrue("hash" !in verified.raw)
+        assertEquals(userJson, verified.raw["user"])
+        assertEquals("Q-42", verified.raw["query_id"])
     }
 
     @Test
-    fun `returns null when hash invalid`() {
-        val parameters =
-            linkedMapOf(
-                "user" to WebAppInitDataTestHelper.encodeUser(id = 1L),
-                "auth_date" to clock.instant().epochSecond.toString(),
-            )
+    fun `bad hash returns null`() {
         val initData =
-            WebAppInitDataTestHelper.createInitData(TEST_BOT_TOKEN, parameters)
-        val tampered = initData.replaceRange(initData.length - 1, initData.length, "0")
+            buildInitData(
+                botToken,
+                mapOf(
+                    "user" to userJson,
+                    "auth_date" to authDateEpoch.toString(),
+                ),
+            )
+        val tampered =
+            initData.replaceRange(
+                initData.length - 1,
+                initData.length,
+                if (initData.last() == 'a') "b" else "a",
+            )
 
-        val verified = WebAppInitDataVerifier.verify(tampered, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+        val verified = WebAppInitDataVerifier.verify(tampered, botToken, maxAge, clock)
 
         assertNull(verified)
     }
 
     @Test
-    fun `returns null when hash missing`() {
-        val parameters =
-            linkedMapOf(
-                "user" to WebAppInitDataTestHelper.encodeUser(id = 5L),
-                "auth_date" to clock.instant().epochSecond.toString(),
+    fun `missing hash returns null`() {
+        val initData =
+            buildInitData(
+                botToken,
+                mapOf(
+                    "user" to userJson,
+                    "auth_date" to authDateEpoch.toString(),
+                ),
             )
-        val encodedPairs =
-            parameters.entries.joinToString("&") { (key, value) ->
-                "$key=${java.net.URLEncoder.encode(value, StandardCharsets.UTF_8)}"
+        val withoutHash = initData.substringBeforeLast("&hash=")
+
+        val verified = WebAppInitDataVerifier.verify(withoutHash, botToken, maxAge, clock)
+
+        assertNull(verified)
+    }
+
+    @Test
+    fun `expired auth date returns null`() {
+        val expiredEpoch = fixedNow.minus(maxAge).minusSeconds(1).epochSecond
+        val initData =
+            buildInitData(
+                botToken,
+                mapOf(
+                    "user" to userJson,
+                    "auth_date" to expiredEpoch.toString(),
+                ),
+            )
+
+        val verified = WebAppInitDataVerifier.verify(initData, botToken, maxAge, clock)
+
+        assertNull(verified)
+    }
+
+    @Test
+    fun `future auth date beyond skew returns null`() {
+        val futureEpoch = fixedNow.plusSeconds(5 * 60).epochSecond
+        val initData =
+            buildInitData(
+                botToken,
+                mapOf(
+                    "user" to userJson,
+                    "auth_date" to futureEpoch.toString(),
+                ),
+            )
+
+        val verified = WebAppInitDataVerifier.verify(initData, botToken, maxAge, clock)
+
+        assertNull(verified)
+    }
+
+    @Test
+    fun `header too long returns null`() {
+        val longInput =
+            buildString {
+                append("a=a")
+                repeat(3000) {
+                    append("&a=a")
+                }
             }
-        val verified = WebAppInitDataVerifier.verify(encodedPairs, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+
+        val verified = WebAppInitDataVerifier.verify(longInput, botToken, maxAge, clock)
 
         assertNull(verified)
     }
 
     @Test
-    fun `returns null when auth date expired`() {
-        val expiredAuthDate = clock.instant().minus(Duration.ofDays(2)).epochSecond.toString()
-        val parameters =
-            linkedMapOf(
-                "user" to WebAppInitDataTestHelper.encodeUser(id = 10L),
-                "auth_date" to expiredAuthDate,
-            )
+    fun `malformed user returns null`() {
         val initData =
-            WebAppInitDataTestHelper.createInitData(TEST_BOT_TOKEN, parameters)
+            buildInitData(
+                botToken,
+                mapOf(
+                    "user" to "{not json}",
+                    "auth_date" to authDateEpoch.toString(),
+                ),
+            )
 
-        val verified = WebAppInitDataVerifier.verify(initData, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+        val verified = WebAppInitDataVerifier.verify(initData, botToken, maxAge, clock)
 
         assertNull(verified)
     }
 
     @Test
-    fun `returns null when header too long`() {
-        val longString = "x".repeat(8205)
-        val verified = WebAppInitDataVerifier.verify(longString, TEST_BOT_TOKEN, Duration.ofHours(24), clock)
+    fun `order independence holds`() {
+        val firstOrder =
+            linkedMapOf(
+                "user" to userJson,
+                "query_id" to "Q-42",
+                "auth_date" to authDateEpoch.toString(),
+            )
+        val initData = buildInitData(botToken, firstOrder)
 
-        assertNull(verified)
+        val secondOrder =
+            linkedMapOf(
+                "auth_date" to authDateEpoch.toString(),
+                "user" to userJson,
+                "query_id" to "Q-42",
+            )
+        val initDataReordered = buildInitData(botToken, secondOrder)
+
+        val verifiedFirst = WebAppInitDataVerifier.verify(initData, botToken, maxAge, clock)
+        val verifiedSecond = WebAppInitDataVerifier.verify(initDataReordered, botToken, maxAge, clock)
+
+        assertNotNull(verifiedFirst)
+        assertNotNull(verifiedSecond)
+        assertEquals(verifiedFirst!!.raw, verifiedSecond!!.raw)
+    }
+
+    @Test
+    fun `uppercase hash is accepted`() {
+        val initData =
+            buildInitData(
+                botToken,
+                mapOf(
+                    "user" to userJson,
+                    "auth_date" to authDateEpoch.toString(),
+                ),
+            )
+        val uppercased =
+            buildString {
+                append(initData.substringBeforeLast('='))
+                append('=')
+                append(initData.substringAfterLast('=').uppercase())
+            }
+
+        val verified = WebAppInitDataVerifier.verify(uppercased, botToken, maxAge, clock)
+
+        assertNotNull(verified)
     }
 }


### PR DESCRIPTION
## Summary
- add deterministic WebApp init data verifier tests covering HMAC derivation, expiry, ordering, and malformed payloads
- extend QR guest list codec tests for failure scenarios, uppercase HMAC, and fuzzed payloads
- add InitDataAuthPlugin integration test and shared helper to build signed init data for other suites

## Testing
- ./gradlew clean build detekt ktlintCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d533d811e08321a5e2368133bd9a34