### PR TITLE
Enable dependency guard and resilient CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: build
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.configuration-cache=true"
+      KOTLIN_VERSION: "2.2.10"
+      KTOR_VERSION: "3.3.0"
+      runIT: "false"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: "gradle"
+
+      - name: Gradle wrapper validate
+        uses: gradle/wrapper-validation-action@v2
+
+      - name: Show Gradle and env
+        run: |
+          ./gradlew --version
+          echo "KOTLIN_VERSION=$KOTLIN_VERSION"
+          echo "KTOR_VERSION=$KTOR_VERSION"
+
+      - name: Lint & Detekt (retry)
+        run: |
+          set -e
+          retry() { n=0; until [ "$n" -ge 3 ]; do "$@" && break; n=$((n+1)); echo "Retry $n..."; sleep 10; done; }
+          retry ./gradlew ktlintFormat ktlintCheck detekt --console=plain
+
+      - name: Dependency Guard
+        run: ./gradlew dependencyGuard --console=plain -PktorEnforcedVersion=$KTOR_VERSION
+
+      - name: Unit tests
+        run: ./gradlew test --console=plain
+
+      - name: Build (retry)
+        run: |
+          set -e
+          retry() { n=0; until [ "$n" -ge 3 ]; do "$@" && break; n=$((n+1)); echo "Retry $n..."; sleep 10; done; }
+          retry ./gradlew clean build --console=plain

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle/
+.kotlin/
 build/
 */build/
 !.gradle/wrapper/gradle-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Related documentation:
 ## Quality gates
 
 ```bash
+./gradlew dependencyGuard --console=plain
 ./gradlew ktlintFormat ktlintCheck detekt --console=plain
 ./gradlew :core-domain:test --console=plain
 ./gradlew clean build --console=plain
@@ -37,6 +38,16 @@ run them locally or in CI, add `-PrunIT=true`:
 ```bash
 ./gradlew test -PrunIT=true --console=plain
 ```
+
+To enable the same integration tests in CI, export `runIT=true` or append
+`-PrunIT=true` to the Gradle invocation inside your workflow step. The default
+GitHub Actions workflow (`.github/workflows/build.yml`) keeps IT disabled to
+avoid provisioning optional services unless explicitly requested.
+
+The dependency guard task validates the resolved dependency graph and fails the
+build if it detects legacy Kotlin stdlib artifacts, mismatched Ktor versions or
+dynamic/SNAPSHOT coordinates. Run it locally via `./gradlew dependencyGuard
+--console=plain` or let CI handle it as part of the standard pipeline.
 
 ## Configuration
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,11 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.daemon=true
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
+kotlin.incremental=true
+kotlin.incremental.useClasspathSnapshot=true
+kotlinVersion=2.2.10
+ktorEnforcedVersion=3.3.0


### PR DESCRIPTION
## Summary
- enable Gradle configuration cache, build cache, and Kotlin defaults in gradle.properties
- collapse legacy Kotlin stdlib variants and add a reusable dependencyGuard verification task
- add a resilient GitHub Actions workflow with retries, caching, and dependency validation, and document the new commands in the README

## Testing
- ./gradlew dependencyGuard --console=plain
- ./gradlew clean build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbeaf6f3f883218e4e4f196a2323db