### PR TITLE
Silence pengrad test deprecation warnings and disable Gradle CoD

### DIFF
--- a/app-bot/src/test/kotlin/com/example/bot/telegram/MenuCallbacksHandlerGuestsFlowTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/telegram/MenuCallbacksHandlerGuestsFlowTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // pengrad: CallbackQuery.message() deprecated в Java API, используем только в тестовых стабах
+
 package com.example.bot.telegram
 
 import com.example.bot.availability.AvailabilityService

--- a/app-bot/src/test/kotlin/com/example/bot/telegram/MenuCallbacksHandlerSmokeTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/telegram/MenuCallbacksHandlerSmokeTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // pengrad: CallbackQuery.message() deprecated в Java API, используем только в тестовых стабах
+
 package com.example.bot.telegram
 
 import com.example.bot.availability.AvailabilityService

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.caching=true
-org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
 kotlin.incremental=true


### PR DESCRIPTION
## Summary
- add file-level suppression for pengrad CallbackQuery.message() deprecation in the affected Telegram bot tests
- remove the org.gradle.configureondemand flag to stop configuration-on-demand warnings during builds

## Testing
- ./gradlew :app-bot:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dd2c3d92fc8321b5d0be49027bce97