### PR TITLE
Scope InitDataAuth plugin to protected routes

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/routes/CheckinRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/CheckinRoutes.kt
@@ -7,6 +7,8 @@ import com.example.bot.metrics.UiCheckinMetrics
 import com.example.bot.security.rbac.ClubScope
 import com.example.bot.security.rbac.authorize
 import com.example.bot.security.rbac.clubScoped
+import com.example.bot.webapp.InitDataAuthConfig
+import com.example.bot.webapp.InitDataAuthPlugin
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
@@ -30,6 +32,7 @@ private data class ScanPayload(val qr: String)
 
 fun Application.checkinRoutes(
     repository: GuestListRepository,
+    initDataAuth: InitDataAuthConfig.() -> Unit,
     qrSecretProvider: () -> String = {
         System.getenv("QR_SECRET") ?: error("QR_SECRET missing")
     },
@@ -40,7 +43,7 @@ fun Application.checkinRoutes(
 
     routing {
         route("/api/clubs/{clubId}/checkin") {
-            // InitDataAuthPlugin ставится глобально в Application.module()
+            install(InitDataAuthPlugin, initDataAuth)
             authorize(Role.CLUB_ADMIN, Role.MANAGER, Role.ENTRY_MANAGER) {
                 clubScoped(ClubScope.Own) {
                     post("/scan") {

--- a/app-bot/src/test/kotlin/com/example/bot/routes/CheckinRoutesTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/routes/CheckinRoutesTest.kt
@@ -88,7 +88,7 @@ class CheckinRoutesTest : StringSpec({
         configureSecurity()
         checkinRoutes(
             repository = repository,
-            initDataBotTokenProvider = { TEST_BOT_TOKEN },
+            initDataAuth = { botTokenProvider = { TEST_BOT_TOKEN } },
             qrSecretProvider = { qrSecret },
             clock = clock,
             qrTtl = qrTtl,

--- a/app-bot/src/test/kotlin/com/example/bot/routes/EntryManagerCheckInSmokeTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/routes/EntryManagerCheckInSmokeTest.kt
@@ -384,7 +384,7 @@ private fun Application.configureTestApplication(module: Module) {
         qrSecretProvider = { QR_SECRET },
         clock = fixedClock,
         qrTtl = qrTtl,
-        initDataBotTokenProvider = { TEST_BOT_TOKEN },
+        initDataAuth = { botTokenProvider = { TEST_BOT_TOKEN } },
     )
 }
 

--- a/app-bot/src/test/kotlin/com/example/bot/webapp/InitDataAuthPluginTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/webapp/InitDataAuthPluginTest.kt
@@ -149,6 +149,12 @@ class InitDataAuthPluginTest {
                 }
             assertEquals(HttpStatusCode.OK, success.status)
 
+            val alias =
+                client.get("/t") {
+                    header("X-Telegram-InitData", header)
+                }
+            assertEquals(HttpStatusCode.OK, alias.status)
+
             val missing = client.get("/t")
             assertEquals(HttpStatusCode.Unauthorized, missing.status)
 


### PR DESCRIPTION
## Summary
- convert InitDataAuthPlugin to a route-scoped plugin that supports header aliases and extracts the principal per protected call
- apply the plugin only on protected route groups while sharing the bot token configuration from Application.module
- refresh route tests to supply valid init data headers and cover the alias handling

## Testing
- ./gradlew :app-bot:compileKotlin --console=plain
- ./gradlew :app-bot:installDist --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e081de703883219f0ba68a81a5875d