### PR TITLE
Serve mini app SPA with CSP and compression

### DIFF
--- a/app-bot/build.gradle.kts
+++ b/app-bot/build.gradle.kts
@@ -1,4 +1,6 @@
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.JavaExec
+import org.gradle.language.jvm.tasks.ProcessResources
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -75,6 +77,28 @@ dependencies {
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.junit)
     testImplementation(projects.coreTesting)
+}
+
+// =========================
+// Mini App assets → resources
+// =========================
+
+val miniAppDist = rootProject.layout.projectDirectory.dir("miniapp/dist").asFile
+
+tasks.register<Copy>("copyMiniAppDist") {
+    description = "Copy Mini App compiled assets into resources so Ktor can serve them from the JAR."
+    group = "build"
+    from(miniAppDist)
+    include("**/*")
+    into(layout.buildDirectory.dir("generated/miniapp/webapp/app"))
+    onlyIf { miniAppDist.exists() && miniAppDist.isDirectory && miniAppDist.listFiles()?.isNotEmpty() == true }
+}
+
+tasks.named<ProcessResources>("processResources") {
+    dependsOn("copyMiniAppDist")
+    from(layout.buildDirectory.dir("generated/miniapp")) {
+        into("")
+    }
 }
 
 application {

--- a/app-bot/src/main/kotlin/com/example/bot/routes/WebAppRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/WebAppRoutes.kt
@@ -1,11 +1,51 @@
 package com.example.bot.routes
 
+import io.ktor.http.ContentType
 import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.application.install
 import io.ktor.server.http.content.staticResources
+import io.ktor.server.plugins.compression.Compression
+import io.ktor.server.plugins.compression.gzip
+import io.ktor.server.plugins.defaultheaders.DefaultHeaders
+import io.ktor.server.response.respondBytes
+import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 
+/**
+ * Раздаёт Mini App (SPA) из ресурсов по пути /app, включает CSP и gzip.
+ */
 fun Application.webAppRoutes() {
+    install(DefaultHeaders) {
+        header(
+            name = "Content-Security-Policy",
+            value =
+                "default-src 'self'; " +
+                    "script-src 'self' 'unsafe-inline' https://*.telegram.org https://*.t.me; " +
+                    "style-src 'self' 'unsafe-inline'; " +
+                    "img-src 'self' data: https:; " +
+                    "connect-src 'self' https://api.telegram.org https://*.t.me https://*.telegram.org; " +
+                    "frame-ancestors https://web.telegram.org https://*.telegram.org https://*.t.me; " +
+                    "base-uri 'self'; form-action 'self';"
+        )
+    }
+
+    install(Compression) {
+        gzip()
+    }
+
+    val classLoader = environment.classLoader
+
     routing {
-        staticResources("/webapp/entry", "webapp/entry")
+        get("/app") {
+            val bytes =
+                classLoader
+                    .getResource("webapp/app/index.html")
+                    ?.readBytes()
+                    ?: error("Mini App index.html not found at resources/webapp/app/index.html")
+            call.respondBytes(bytes, ContentType.Text.Html)
+        }
+
+        staticResources("/app", "webapp/app")
     }
 }


### PR DESCRIPTION
## Summary
- serve the mini app SPA from /app with CSP headers and gzip compression
- copy built mini app assets into the backend resources during processResources

## Testing
- ./gradlew :app-bot:compileKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e08918ac608321bf4d0768403b95bc