### PR TITLE
Add public clubs endpoint for Mini App

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/Application.kt
@@ -23,6 +23,7 @@ import com.example.bot.plugins.meterRegistry
 import com.example.bot.render.DefaultHallRenderer
 import com.example.bot.routes.availabilityRoutes
 import com.example.bot.routes.checkinRoutes
+import com.example.bot.routes.clubsPublicRoutes
 import com.example.bot.routes.guestFlowRoutes
 import com.example.bot.routes.guestListRoutes
 import com.example.bot.routes.hallImageRoute
@@ -198,6 +199,8 @@ fun Application.module() {
         // Публичный API доступности: ночи и свободные столы
         availabilityRoutes(availability)
     }
+
+    clubsPublicRoutes(clubRepository)
 
     // Mini App статика, CSP, gzip
     webAppRoutes()

--- a/app-bot/src/main/kotlin/com/example/bot/routes/ClubsRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/ClubsRoutes.kt
@@ -1,0 +1,39 @@
+package com.example.bot.routes
+
+import com.example.bot.data.repo.ClubRepository
+import com.example.bot.data.repo.ClubDto as ClubProjection
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ClubDto(
+    val id: Long,
+    val name: String,
+)
+
+private fun ClubProjection.toDto(): ClubDto {
+    return ClubDto(
+        id = id,
+        name = name,
+    )
+}
+
+fun Application.clubsPublicRoutes(repository: ClubRepository) {
+    routing {
+        get("/api/clubs") {
+            val clubs =
+                withContext(Dispatchers.IO) {
+                    repository.listClubs(limit = Int.MAX_VALUE)
+                }
+            val response = clubs.map { it.toDto() }
+            call.application.log.info("clubs_public.list count={}", response.size)
+            call.respond(response)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a public `/api/clubs` route that exposes club id and name for the Mini App picker
- map repository projections to a serializable DTO and log the returned list size
- register the new router in the application module without attaching auth/InitData plugins

## Testing
- ./gradlew :app-bot:test *(fails: Could not evaluate onlyIf predicate for task ':app-bot:copyMiniAppDist')*


------
https://chatgpt.com/codex/tasks/task_e_68e08b0d96708321a944308c9b866b22