### PR TITLE
Add REST endpoint to finalize bookings

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/Application.kt
@@ -23,6 +23,7 @@ import com.example.bot.plugins.meterRegistry
 import com.example.bot.render.DefaultHallRenderer
 import com.example.bot.routes.availabilityApiRoutes
 import com.example.bot.routes.availabilityRoutes
+import com.example.bot.routes.bookingFinalizeRoutes
 import com.example.bot.routes.checkinRoutes
 import com.example.bot.routes.clubsPublicRoutes
 import com.example.bot.routes.guestFlowRoutes
@@ -211,6 +212,8 @@ fun Application.module() {
 
     // Чек-ин верификатор (WebApp → POST /api/clubs/{clubId}/checkin/scan)
     checkinRoutes(repository = guestListRepository, initDataAuth = initDataAuthConfig)
+
+    bookingFinalizeRoutes(bookingService) { telegramToken }
 
     // RBAC-защищённые брони: /api/clubs/{clubId}/bookings/hold|confirm
     securedRoutes(bookingService, initDataAuth = initDataAuthConfig)

--- a/app-bot/src/main/kotlin/com/example/bot/routes/BookingFinalizeRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/BookingFinalizeRoutes.kt
@@ -1,0 +1,78 @@
+package com.example.bot.routes
+
+import com.example.bot.booking.BookingCmdResult
+import com.example.bot.booking.BookingService
+import com.example.bot.webapp.InitDataAuthPlugin
+import com.example.bot.webapp.InitDataPrincipalKey
+import com.example.bot.webapp.TelegramPrincipal
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import org.slf4j.MDC
+
+fun Application.bookingFinalizeRoutes(
+    bookingService: BookingService,
+    initDataBotTokenProvider: () -> String = {
+        System.getenv("TELEGRAM_BOT_TOKEN") ?: error("TELEGRAM_BOT_TOKEN missing")
+    },
+) {
+    routing {
+        route("/api/clubs/{clubId}/bookings") {
+            install(InitDataAuthPlugin) {
+                botTokenProvider = initDataBotTokenProvider
+            }
+
+            post("/finalize") {
+                call.parameters["clubId"]?.toLongOrNull()
+                    ?: return@post call.respond(HttpStatusCode.BadRequest, "Invalid clubId")
+
+                val principal: TelegramPrincipal = call.attributes[InitDataPrincipalKey]
+                val telegramUserId = principal.userId
+
+                val payload = runCatching { call.receive<FinalizePayload>() }.getOrNull()
+                    ?: return@post call.respond(HttpStatusCode.BadRequest, "Invalid JSON")
+
+                val bookingId = runCatching { UUID.fromString(payload.bookingId) }.getOrNull()
+                    ?: return@post call.respond(HttpStatusCode.BadRequest, "Invalid bookingId")
+
+                val idem = call.request.headers["Idempotency-Key"] ?: "finalize:$bookingId"
+                MDC.put("Idempotency-Key", idem)
+
+                try {
+                    val result = bookingService.finalize(bookingId, telegramUserId)
+
+                    when (result) {
+                        is BookingCmdResult.Booked -> {
+                            call.respond(
+                                HttpStatusCode.OK,
+                                mapOf("status" to "booked", "bookingId" to result.bookingId.toString()),
+                            )
+                        }
+                        else -> {
+                            call.respond(
+                                HttpStatusCode.Conflict,
+                                mapOf(
+                                    "status" to "failed",
+                                    "code" to (result::class.simpleName ?: "Unknown"),
+                                    "bookingId" to bookingId.toString(),
+                                ),
+                            )
+                        }
+                    }
+                } finally {
+                    MDC.remove("Idempotency-Key")
+                }
+            }
+        }
+    }
+}
+
+@Serializable
+private data class FinalizePayload(val bookingId: String)


### PR DESCRIPTION
## Summary
- add booking finalize route that validates Telegram init data and maps booking results
- register the finalize route in the application module with scoped InitDataAuthPlugin usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e09503d0f8832198c7f1308109deeb