### PR TITLE
Add Mini App check-in compatibility routes

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/Application.kt
@@ -24,6 +24,7 @@ import com.example.bot.render.DefaultHallRenderer
 import com.example.bot.routes.availabilityApiRoutes
 import com.example.bot.routes.availabilityRoutes
 import com.example.bot.routes.bookingFinalizeRoutes
+import com.example.bot.routes.checkinCompatRoutes
 import com.example.bot.routes.checkinRoutes
 import com.example.bot.routes.clubsPublicRoutes
 import com.example.bot.routes.guestFlowRoutes
@@ -212,6 +213,8 @@ fun Application.module() {
 
     // Чек-ин верификатор (WebApp → POST /api/clubs/{clubId}/checkin/scan)
     checkinRoutes(repository = guestListRepository, initDataAuth = initDataAuthConfig)
+    // алиасы для Mini App коротких путей
+    checkinCompatRoutes(repository = guestListRepository)
 
     bookingFinalizeRoutes(bookingService) { telegramToken }
 

--- a/app-bot/src/main/kotlin/com/example/bot/routes/CheckinCompatRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/CheckinCompatRoutes.kt
@@ -1,0 +1,102 @@
+package com.example.bot.routes
+
+import com.example.bot.data.security.Role
+import com.example.bot.guestlists.GuestListRepository
+import com.example.bot.metrics.UiCheckinMetrics
+import com.example.bot.security.rbac.authorize
+import com.example.bot.webapp.InitDataAuthPlugin
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import kotlinx.serialization.Serializable
+import java.time.Clock
+import java.time.Duration
+
+private val DEFAULT_QR_TTL: Duration = Duration.ofHours(12)
+private val INIT_DATA_MAX_AGE: Duration = Duration.ofHours(24)
+
+@Serializable
+private data class QrPayload(
+    val qr: String,
+    val clubId: Long? = null,
+)
+
+@Suppress("UNUSED_PARAMETER")
+fun Application.checkinCompatRoutes(
+    repository: GuestListRepository,
+    initDataBotTokenProvider: () -> String = {
+        System.getenv("TELEGRAM_BOT_TOKEN") ?: error("TELEGRAM_BOT_TOKEN missing")
+    },
+    qrSecretProvider: () -> String = {
+        System.getenv("QR_SECRET") ?: error("QR_SECRET missing")
+    },
+    clock: Clock = Clock.systemUTC(),
+    qrTtl: Duration = DEFAULT_QR_TTL,
+) {
+    routing {
+        route("/api/checkin") {
+            install(InitDataAuthPlugin) {
+                botTokenProvider = initDataBotTokenProvider
+                maxAge = INIT_DATA_MAX_AGE
+                this.clock = clock
+            }
+
+            authorize(Role.CLUB_ADMIN, Role.MANAGER, Role.ENTRY_MANAGER) {
+                post("/qr") {
+                    UiCheckinMetrics.incTotal()
+                    UiCheckinMetrics.timeScan {
+                        val payload = runCatching { call.receive<QrPayload>() }.getOrNull()
+                            ?: run {
+                                UiCheckinMetrics.incError()
+                                call.respond(HttpStatusCode.BadRequest, "Invalid JSON")
+                                return@timeScan
+                            }
+
+                        val qr = payload.qr.trim()
+                        if (qr.isEmpty()) {
+                            UiCheckinMetrics.incError()
+                            call.respond(HttpStatusCode.BadRequest, "Empty QR")
+                            return@timeScan
+                        }
+
+                        val clubId = payload.clubId
+                            ?: run {
+                                UiCheckinMetrics.incError()
+                                call.respond(HttpStatusCode.BadRequest, "clubId is required")
+                                return@timeScan
+                            }
+
+                        val location = "/api/clubs/$clubId/checkin/scan"
+                        call.response.headers.append(HttpHeaders.Location, location)
+                        call.respond(HttpStatusCode.TemporaryRedirect)
+
+                        // If front-end cannot follow redirects, inline processing from CheckinRoutes can
+                        // be added here by copying the scan logic and performing the same checks.
+                    }
+                }
+
+                get("/search") {
+                    call.respond(
+                        HttpStatusCode.NotImplemented,
+                        mapOf("status" to "not_implemented", "feature" to "checkin_search"),
+                    )
+                }
+
+                post("/plus-one") {
+                    call.respond(
+                        HttpStatusCode.NotImplemented,
+                        mapOf("status" to "not_implemented", "feature" to "checkin_plus_one"),
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add /api/checkin routing group secured with InitDataAuthPlugin and RBAC for Mini App compatibility
- implement QR alias redirecting to existing scan endpoint and return stubs for search and plus-one
- register the new compatibility routes alongside existing check-in routes

## Testing
- ./gradlew :app-bot:compileKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e0998d7da0832194f3fb1cc5e780ae