### PR TITLE
Add music mini app API with service and wiring

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/di/musicModule.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/di/musicModule.kt
@@ -1,0 +1,16 @@
+@file:Suppress("Filename")
+
+package com.example.bot.di
+
+import com.example.bot.data.music.MusicItemRepositoryImpl
+import com.example.bot.data.music.MusicPlaylistRepositoryImpl
+import com.example.bot.music.MusicItemRepository
+import com.example.bot.music.MusicPlaylistRepository
+import com.example.bot.music.MusicService
+import org.koin.dsl.module
+
+val musicModule = module {
+    single<MusicItemRepository> { MusicItemRepositoryImpl(get()) }
+    single<MusicPlaylistRepository> { MusicPlaylistRepositoryImpl(get()) }
+    single { MusicService(get(), get(), get()) }
+}

--- a/app-bot/src/main/kotlin/com/example/bot/music/MusicService.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/music/MusicService.kt
@@ -1,0 +1,103 @@
+package com.example.bot.music
+
+import com.example.bot.routes.dto.MusicItemDto
+import com.example.bot.routes.dto.MusicPlaylistDetailsDto
+import com.example.bot.routes.dto.MusicPlaylistDto
+import java.security.MessageDigest
+import java.time.Clock
+import java.time.Instant
+import java.util.Base64
+
+class MusicService(
+    private val itemsRepo: MusicItemRepository,
+    private val playlistsRepo: MusicPlaylistRepository,
+    private val clock: Clock,
+) {
+    suspend fun listItems(limit: Int = 100): Pair<String, List<MusicItemDto>> {
+        val items =
+            itemsRepo.listActive(
+                clubId = null,
+                limit = limit,
+                offset = 0,
+                tag = null,
+                q = null,
+            )
+        val etag = etagFor(
+            updatedAt = itemsRepo.lastUpdatedAt(),
+            count = items.size,
+            seed = "items",
+        )
+        val payload = items.map {
+            MusicItemDto(
+                id = it.id,
+                title = it.title,
+                artist = it.dj,
+                durationSec = it.durationSec,
+                coverUrl = it.coverUrl,
+            )
+        }
+        return etag to payload
+    }
+
+    suspend fun listPlaylists(limit: Int = 100): Pair<String, List<MusicPlaylistDto>> {
+        val playlists = playlistsRepo.listActive(limit)
+        val counts = playlistsRepo.itemsCount(playlists.map { it.id })
+        val etag = etagFor(
+            updatedAt = playlistsRepo.lastUpdatedAt(),
+            count = playlists.size,
+            seed = "playlists",
+        )
+        val payload = playlists.map {
+            MusicPlaylistDto(
+                id = it.id,
+                name = it.title,
+                description = it.description,
+                coverUrl = it.coverUrl,
+                itemsCount = counts[it.id] ?: 0,
+            )
+        }
+        return etag to payload
+    }
+
+    suspend fun getPlaylist(id: Long): Pair<String, MusicPlaylistDetailsDto>? {
+        val playlist = playlistsRepo.getFull(id) ?: return null
+        val etag = etagFor(
+            updatedAt = playlistsRepo.lastUpdatedAt(),
+            count = playlist.items.size,
+            seed = "playlist:$id",
+        )
+        val payload = MusicPlaylistDetailsDto(
+            id = playlist.id,
+            name = playlist.title,
+            description = playlist.description,
+            coverUrl = playlist.coverUrl,
+            items = playlist.items.map {
+                MusicItemDto(
+                    id = it.id,
+                    title = it.title,
+                    artist = it.dj,
+                    durationSec = it.durationSec,
+                    coverUrl = it.coverUrl,
+                )
+            },
+        )
+        return etag to payload
+    }
+
+    private fun etagFor(
+        updatedAt: Instant?,
+        count: Int,
+        seed: String,
+    ): String {
+        val window = clock.millis() / (MILLIS_IN_SECOND * SECONDS_IN_MINUTE * ETAG_WINDOW_MINUTES)
+        val source = "${updatedAt ?: Instant.EPOCH}|$count|$seed|$window"
+        val md = MessageDigest.getInstance("SHA-256")
+        val hash = md.digest(source.toByteArray())
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash).take(ETAG_LENGTH)
+    }
+}
+
+private const val MILLIS_IN_SECOND = 1_000L
+private const val SECONDS_IN_MINUTE = 60L
+private const val ETAG_WINDOW_MINUTES = 5L
+private const val ETAG_LENGTH = 27

--- a/app-bot/src/main/kotlin/com/example/bot/routes/dto/MusicDtos.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/dto/MusicDtos.kt
@@ -1,0 +1,32 @@
+@file:Suppress("MagicNumber")
+
+package com.example.bot.routes.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MusicItemDto(
+    val id: Long,
+    val title: String,
+    val artist: String? = null,
+    val durationSec: Int? = null,
+    val coverUrl: String? = null,
+)
+
+@Serializable
+data class MusicPlaylistDto(
+    val id: Long,
+    val name: String,
+    val description: String? = null,
+    val coverUrl: String? = null,
+    val itemsCount: Int = 0,
+)
+
+@Serializable
+data class MusicPlaylistDetailsDto(
+    val id: Long,
+    val name: String,
+    val description: String? = null,
+    val coverUrl: String? = null,
+    val items: List<MusicItemDto> = emptyList(),
+)

--- a/app-bot/src/main/kotlin/com/example/bot/telegram/MusicHandlers.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/telegram/MusicHandlers.kt
@@ -1,18 +1,18 @@
 package com.example.bot.telegram
 
-import com.example.bot.music.MusicService
+import com.example.bot.music.MusicCatalogService
 import com.pengrad.telegrambot.model.Update
 import com.pengrad.telegrambot.request.SendAudio
 import com.pengrad.telegrambot.request.SendMessage
 import com.pengrad.telegrambot.response.BaseResponse
 
 /** Telegram handlers for music commands. */
-class MusicHandlers(private val send: suspend (Any) -> BaseResponse, private val service: MusicService) {
+class MusicHandlers(private val send: suspend (Any) -> BaseResponse, private val service: MusicCatalogService) {
     /** Handles /music command by listing recent items. */
     suspend fun handle(update: Update) {
         val msg = update.message() ?: return
         val chatId = msg.chat().id()
-        val items = service.listItems(MusicService.ItemFilter(limit = 5))
+        val items = service.listItems(MusicCatalogService.ItemFilter(limit = 5))
         for (item in items) {
             val fileId = item.telegramFileId
             if (fileId != null) {

--- a/app-bot/src/test/kotlin/com/example/bot/routes/MusicRoutesTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/routes/MusicRoutesTest.kt
@@ -1,0 +1,251 @@
+package com.example.bot.routes
+
+import com.example.bot.music.MusicItemCreate
+import com.example.bot.music.MusicItemRepository
+import com.example.bot.music.MusicItemView
+import com.example.bot.music.MusicPlaylistRepository
+import com.example.bot.music.MusicService
+import com.example.bot.music.MusicSource
+import com.example.bot.music.PlaylistCreate
+import com.example.bot.music.PlaylistFullView
+import com.example.bot.music.PlaylistView
+import com.example.bot.music.UserId
+import com.example.bot.webapp.TEST_BOT_TOKEN
+import com.example.bot.webapp.WebAppInitDataTestHelper
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Field
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class MusicRoutesTest {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val fixedClock: Clock = Clock.fixed(Instant.parse("2024-05-01T10:15:30Z"), ZoneOffset.UTC)
+    private val updatedAt: Instant = Instant.parse("2024-05-01T09:00:00Z")
+    private val items =
+        listOf(
+            MusicItemView(
+                id = 1,
+                clubId = null,
+                title = "Track A",
+                dj = "Artist 1",
+                source = MusicSource.SPOTIFY,
+                sourceUrl = null,
+                telegramFileId = null,
+                durationSec = 210,
+                coverUrl = "https://example.com/a.jpg",
+                tags = emptyList(),
+                publishedAt = updatedAt,
+            ),
+            MusicItemView(
+                id = 2,
+                clubId = null,
+                title = "Track B",
+                dj = "Artist 2",
+                source = MusicSource.SPOTIFY,
+                sourceUrl = null,
+                telegramFileId = null,
+                durationSec = 180,
+                coverUrl = "https://example.com/b.jpg",
+                tags = emptyList(),
+                publishedAt = updatedAt,
+            ),
+        )
+    private val playlists =
+        listOf(
+            PlaylistView(
+                id = 10,
+                clubId = null,
+                title = "Top Hits",
+                description = "Best of",
+                coverUrl = "https://example.com/pl.jpg",
+            ),
+        )
+    private val playlistItems = mapOf(10L to items)
+
+    private val service =
+        MusicService(
+            itemsRepo = FakeMusicItemRepository(items, updatedAt),
+            playlistsRepo = FakeMusicPlaylistRepository(playlists, playlistItems, updatedAt),
+            clock = fixedClock,
+        )
+
+    @BeforeEach
+    fun setupEnv() {
+        setEnv("TELEGRAM_BOT_TOKEN", TEST_BOT_TOKEN)
+    }
+
+    @Test
+    fun `items endpoint returns list and respects etag`() {
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                musicRoutes(service)
+            }
+
+            val initData = createInitData()
+
+            val firstResponse =
+                client.get("/api/music/items") {
+                    header("X-Telegram-Init-Data", initData)
+                }
+            assertEquals(HttpStatusCode.OK, firstResponse.status)
+            val etag = firstResponse.headers[HttpHeaders.ETag]
+            assertNotNull(etag)
+            val body = json.parseToJsonElement(firstResponse.bodyAsText())
+            assertEquals(2, body.jsonArray.size)
+
+            val cachedResponse =
+                client.get("/api/music/items") {
+                    header("X-Telegram-Init-Data", initData)
+                    header(HttpHeaders.IfNoneMatch, etag)
+                }
+            assertEquals(HttpStatusCode.NotModified, cachedResponse.status)
+        }
+    }
+
+    @Test
+    fun `playlists endpoint returns list`() {
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                musicRoutes(service)
+            }
+
+            val response =
+                client.get("/api/music/playlists") {
+                    header("X-Telegram-Init-Data", createInitData())
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            val payload = json.parseToJsonElement(response.bodyAsText())
+            assertEquals(1, payload.jsonArray.size)
+        }
+    }
+
+    @Test
+    fun `playlist details return 200 and 404`() {
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                musicRoutes(service)
+            }
+
+            val okResponse =
+                client.get("/api/music/playlists/10") {
+                    header("X-Telegram-Init-Data", createInitData())
+                }
+            assertEquals(HttpStatusCode.OK, okResponse.status)
+            val details = json.parseToJsonElement(okResponse.bodyAsText())
+            assertEquals("Top Hits", details.jsonObject["name"]?.jsonPrimitive?.content)
+
+            val notFound =
+                client.get("/api/music/playlists/999") {
+                    header("X-Telegram-Init-Data", createInitData())
+                }
+            assertEquals(HttpStatusCode.NotFound, notFound.status)
+        }
+    }
+
+    private fun createInitData(): String {
+        val params =
+            linkedMapOf(
+                "user" to WebAppInitDataTestHelper.encodeUser(id = 777, username = "tester"),
+                "auth_date" to Instant.now().epochSecond.toString(),
+            )
+        return WebAppInitDataTestHelper.createInitData(TEST_BOT_TOKEN, params)
+    }
+
+    private fun setEnv(name: String, value: String) {
+        try {
+            val processEnvironmentClass =
+                Class.forName("java.lang.ProcessEnvironment")
+            val theEnvironmentField: Field =
+                processEnvironmentClass.getDeclaredField("theEnvironment")
+            theEnvironmentField.isAccessible = true
+            val env = theEnvironmentField.get(null) as MutableMap<String, String>
+            env[name] = value
+            val theCaseInsensitiveEnvironmentField: Field =
+                processEnvironmentClass.getDeclaredField("theCaseInsensitiveEnvironment")
+            theCaseInsensitiveEnvironmentField.isAccessible = true
+            val cienv =
+                theCaseInsensitiveEnvironmentField.get(null) as MutableMap<String, String>
+            cienv[name] = value
+        } catch (_: NoSuchFieldException) {
+            val env = System.getenv()
+            val cl = env.javaClass
+            val field = cl.getDeclaredField("m")
+            field.isAccessible = true
+            val map = field.get(env) as MutableMap<String, String>
+            map[name] = value
+        }
+    }
+
+    private class FakeMusicItemRepository(
+        private val items: List<MusicItemView>,
+        private val updatedAt: Instant?,
+    ) : MusicItemRepository {
+        override suspend fun create(
+            req: MusicItemCreate,
+            actor: UserId,
+        ): MusicItemView = throw UnsupportedOperationException("Not implemented")
+
+        override suspend fun listActive(
+            clubId: Long?,
+            limit: Int,
+            offset: Int,
+            tag: String?,
+            q: String?,
+        ): List<MusicItemView> = items.drop(offset).take(limit)
+
+        override suspend fun lastUpdatedAt(): Instant? = updatedAt
+    }
+
+    private class FakeMusicPlaylistRepository(
+        private val playlists: List<PlaylistView>,
+        private val itemsByPlaylist: Map<Long, List<MusicItemView>>,
+        private val updatedAt: Instant?,
+    ) : MusicPlaylistRepository {
+        override suspend fun create(
+            req: PlaylistCreate,
+            actor: UserId,
+        ): PlaylistView = throw UnsupportedOperationException("Not implemented")
+
+        override suspend fun setItems(
+            playlistId: Long,
+            itemIds: List<Long>,
+        ) = throw UnsupportedOperationException("Not implemented")
+
+        override suspend fun listActive(limit: Int, offset: Int): List<PlaylistView> = playlists.drop(offset).take(limit)
+
+        override suspend fun itemsCount(playlistIds: Collection<Long>): Map<Long, Int> =
+            playlistIds.associateWith { id -> itemsByPlaylist[id]?.size ?: 0 }
+
+        override suspend fun getFull(id: Long): PlaylistFullView? {
+            val view = playlists.firstOrNull { it.id == id }
+            val items = itemsByPlaylist[id]
+            return if (view != null && items != null) {
+                PlaylistFullView(view.id, view.clubId, view.title, view.description, view.coverUrl, items)
+            } else {
+                null
+            }
+        }
+
+        override suspend fun lastUpdatedAt(): Instant? = updatedAt
+    }
+}

--- a/core-domain/src/main/kotlin/com/example/bot/music/MusicCatalogService.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/music/MusicCatalogService.kt
@@ -1,7 +1,7 @@
 package com.example.bot.music
 
 /** Service orchestrating music repositories. */
-class MusicService(private val items: MusicItemRepository, private val playlists: MusicPlaylistRepository) {
+class MusicCatalogService(private val items: MusicItemRepository, private val playlists: MusicPlaylistRepository) {
     suspend fun createItem(
         req: MusicItemCreate,
         actor: UserId,

--- a/core-domain/src/main/kotlin/com/example/bot/music/Repositories.kt
+++ b/core-domain/src/main/kotlin/com/example/bot/music/Repositories.kt
@@ -1,5 +1,7 @@
 package com.example.bot.music
 
+import java.time.Instant
+
 /** Repository for music items. */
 interface MusicItemRepository {
     suspend fun create(
@@ -14,6 +16,8 @@ interface MusicItemRepository {
         tag: String?,
         q: String?,
     ): List<MusicItemView>
+
+    suspend fun lastUpdatedAt(): Instant?
 }
 
 /** Repository for music playlists. */
@@ -28,5 +32,11 @@ interface MusicPlaylistRepository {
         itemIds: List<Long>,
     )
 
+    suspend fun listActive(limit: Int, offset: Int = 0): List<PlaylistView>
+
+    suspend fun itemsCount(playlistIds: Collection<Long>): Map<Long, Int>
+
     suspend fun getFull(id: Long): PlaylistFullView?
+
+    suspend fun lastUpdatedAt(): Instant?
 }


### PR DESCRIPTION
## Summary
- add DTOs, service, and Ktor routes for the music mini app API with ETag handling and InitData auth
- register music repositories and service in a dedicated Koin module and wire the routes in the application entrypoint
- extend music repositories with last-updated helpers and add coverage tests for the new endpoints

## Testing
- `./gradlew detekt ktlintCheck :app-bot:test :app-bot:installDist --console=plain` *(fails: repository contains pre-existing ktlint issues outside the touched files)*
- `./gradlew :app-bot:test --tests com.example.bot.routes.MusicRoutesTest --console=plain` *(fails: existing :app-bot:copyMiniAppDist task configuration issue)*

------
https://chatgpt.com/codex/tasks/task_e_68e09d3a001c8321b485a3463ba52f94