### PR TITLE
Add Telegram run mode branching for polling and webhook

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/routes/TelegramWebhookRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/TelegramWebhookRoutes.kt
@@ -1,0 +1,37 @@
+package com.example.bot.routes
+
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.Update
+import com.pengrad.telegrambot.utility.BotUtils
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import org.slf4j.LoggerFactory
+
+fun Application.telegramWebhookRoutes(
+    _bot: TelegramBot,
+    onUpdate: (Update) -> Unit,
+) {
+    val logger = LoggerFactory.getLogger("TelegramWebhookRoutes")
+
+    routing {
+        post("/telegram/webhook") {
+            val body = call.receiveText()
+            val update = runCatching { BotUtils.parseUpdate(body) }.getOrNull()
+            if (update == null) {
+                logger.warn("webhook: invalid update payload")
+                call.respond(HttpStatusCode.BadRequest)
+                return@post
+            }
+
+            runCatching { onUpdate(update) }
+                .onFailure { t -> logger.warn("webhook: handler failed: {}", t.toString()) }
+
+            call.respond(HttpStatusCode.OK, "OK")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- derive the bot run mode from AppConfig or TELEGRAM_USE_POLLING and log the selected mode
- branch Telegram startup to delete the webhook and start long polling or to configure webhook routes and telemetry
- add a minimal /telegram/webhook route that parses updates and delegates to existing handlers

## Testing
- ./gradlew :app-bot:compileKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e0a4e114e88321a26066b4561e706a