### PR TITLE
Fix Telegram run mode handling and music count overflow

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/routes/TelegramWebhookRoutes.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/routes/TelegramWebhookRoutes.kt
@@ -1,0 +1,50 @@
+package com.example.bot.routes
+
+import com.pengrad.telegrambot.utility.BotUtils
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.Update
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.request.header
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import org.slf4j.LoggerFactory
+
+private const val SECRET_HEADER = "X-Telegram-Bot-Api-Secret-Token"
+
+fun Application.telegramWebhookRoutes(
+    _bot: TelegramBot,
+    expectedSecret: String?,
+    onUpdate: (Update) -> Unit,
+) {
+    val logger = LoggerFactory.getLogger("TelegramWebhookRoutes")
+
+    routing {
+        post("/telegram/webhook") {
+            if (!expectedSecret.isNullOrBlank()) {
+                val providedSecret = call.request.header(SECRET_HEADER)
+                if (providedSecret != expectedSecret) {
+                    logger.warn("webhook: invalid secret token")
+                    call.respond(HttpStatusCode.Unauthorized)
+                    return@post
+                }
+            }
+
+            val body = call.receiveText()
+            val update = runCatching { BotUtils.parseUpdate(body) }.getOrNull()
+            if (update == null) {
+                logger.warn("webhook: invalid update payload")
+                call.respond(HttpStatusCode.BadRequest)
+                return@post
+            }
+
+            runCatching { onUpdate(update) }
+                .onFailure { t -> logger.warn("webhook: handler failed: {}", t.toString()) }
+
+            call.respond(HttpStatusCode.OK, "OK")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- clamp playlist item counts to `Int` with overflow warnings to satisfy repository contract
- route Telegram updates through a coroutine scope, branch polling/webhook startup safely, and guard webhook API calls
- secure the Telegram webhook route with secret token validation and resilient update parsing

## Testing
- ./gradlew :core-data:compileKotlin --console=plain
- ./gradlew :app-bot:compileKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e1bb7bd27c832197e34facdf28c81e