### PR TITLE
Add reusable Telegram init data test helpers

### DIFF
--- a/app-bot/src/test/kotlin/com/example/bot/testing/TestInitData.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/testing/TestInitData.kt
@@ -1,0 +1,43 @@
+package com.example.bot.testing
+
+import io.ktor.client.request.HttpRequestBuilder
+import java.util.Base64
+import kotlin.text.Charsets.UTF_8
+
+/**
+ * Утилиты initData для тестов. Подпись не проверяется (профиль TEST).
+ */
+public fun createInitData(
+    userId: Long = 123_456_789L,
+    username: String? = "test_user",
+    clubId: Long? = null,
+): String {
+    val encoder = Base64.getEncoder()
+    val userJson = buildString {
+        append('{')
+        append("\"id\":")
+        append(userId)
+        if (username != null) {
+            append(',')
+            append("\"username\":\"")
+            append(username)
+            append('\"')
+        }
+        append('}')
+    }
+
+    val parts = mutableListOf("user=${encoder.encodeToString(userJson.toByteArray(UTF_8))}")
+    clubId?.let { club ->
+        val stateJson = """{"clubId":$club}"""
+        parts += "state=${encoder.encodeToString(stateJson.toByteArray(UTF_8))}"
+    }
+    return parts.joinToString("&")
+}
+
+/**
+ * Вешаем оба заголовка-алиаса, чтобы покрыть X-Telegram-Init-Data и X-Telegram-InitData.
+ */
+public fun HttpRequestBuilder.withInitData(initData: String) {
+    headers.append("X-Telegram-Init-Data", initData)
+    headers.append("X-Telegram-InitData", initData)
+}

--- a/app-bot/src/test/kotlin/com/example/bot/testing/TestKtorExtensions.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/testing/TestKtorExtensions.kt
@@ -1,0 +1,21 @@
+package com.example.bot.testing
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.server.testing.ApplicationTestBuilder
+
+/**
+ * Совместимость со старым DSL: создаёт клиент с "default headers".
+ * Пример:
+ *   val authed = defaultRequest { withInitData(createInitData()) }
+ *   val resp = authed.get("/api/...")
+ */
+public fun ApplicationTestBuilder.defaultRequest(
+    block: HttpRequestBuilder.() -> Unit,
+): HttpClient = createClient {
+    defaultRequest {
+        val requestBuilder = HttpRequestBuilder().apply(block)
+        headers.appendAll(requestBuilder.headers.build())
+    }
+}

--- a/app-bot/src/test/kotlin/com/example/bot/testing/TestRequestExtensions.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/testing/TestRequestExtensions.kt
@@ -1,0 +1,28 @@
+package com.example.bot.testing
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.path
+
+/**
+ * Тестовые экстеншены для совместимости с существующим кодом.
+ * Если в тестах уже есть import io.ktor.client.request.header, этот header не помешает;
+ * при отсутствии импорта — даст компиляцию.
+ */
+public fun HttpRequestBuilder.header(name: String, value: String) {
+    headers.append(name, value)
+}
+
+/**
+ * Упрощённая установка пути запроса в тестах.
+ */
+public fun HttpRequestBuilder.route(pathValue: String) {
+    url {
+        val normalized = pathValue.trimStart('/')
+        val segments = normalized.split('/').filter { it.isNotEmpty() }
+        if (segments.isEmpty()) {
+            path("")
+        } else {
+            path(*segments.toTypedArray())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared test utilities for generating Telegram init data and default request clients used in tests
- update guest list and secured booking route tests to rely on the shared helpers and the new request DSL

## Testing
- ./gradlew :app-bot:compileTestKotlin --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68e3fecb67b48321a82b211dd5753f8c