### PR TITLE
Add application test configuration

### DIFF
--- a/app-bot/src/test/resources/application-test.conf
+++ b/app-bot/src/test/resources/application-test.conf
@@ -1,0 +1,11 @@
+app {
+  profile = "TEST"
+}
+ktor {
+  deployment {
+    port = 0
+  }
+  application {
+    modules = [ com.example.bot.ApplicationKt.module ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight test application configuration to enable the TEST profile
- configure the Ktor test deployment to use an ephemeral port and register the module

## Testing
- ./gradlew :app-bot:compileTestKotlin --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68e52026333483218a9f77ed892289b6