### PR TITLE
Add test profile guard in Application.module

### DIFF
--- a/app-bot/src/main/kotlin/com/example/bot/Application.kt
+++ b/app-bot/src/main/kotlin/com/example/bot/Application.kt
@@ -110,13 +110,30 @@ fun main() {
 
 @Suppress("unused", "LoopWithTooManyJumpStatements", "MaxLineLength")
 fun Application.module() {
+    // 0) Профиль приложения
+    val appProfile: String =
+        environment.config.propertyOrNull("app.profile")?.getString()
+            ?: System.getenv("APP_PROFILE")
+            ?: "DEV"
+    val isTestProfile: Boolean = appProfile.equals("TEST", ignoreCase = true)
+
+    if (isTestProfile) {
+        install(ContentNegotiation) { json() }
+        routing {
+            get("/health") { call.respondText("OK", ContentType.Text.Plain) }
+            get("/ready") { call.respondText("READY", ContentType.Text.Plain) }
+            get("/ping") { call.respondText("OK", ContentType.Text.Plain) }
+        }
+        return
+    }
+
     // demo constants
     val demoStateKey = BotLimits.Demo.STATE_KEY
     val demoClubId = BotLimits.Demo.CLUB_ID
     val demoStartUtc = BotLimits.Demo.START_UTC
     val demoTableIds = BotLimits.Demo.TABLE_IDS
 
-    // 0) Тюнинг сервера и наблюдаемость
+    // 1) Тюнинг сервера и наблюдаемость
     installServerTuning()
     installRateLimitPluginDefaults()
     installMetrics()


### PR DESCRIPTION
## Summary
- add a TEST profile guard in the Ktor application module that skips heavy initialization
- expose only /health, /ready, and /ping routes when running under the TEST profile

## Testing
- ./gradlew :app-bot:test --tests com.example.bot.SmokeRoutesTest --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68e52a0b13bc8321b8d16eb58c127aa6