### PR TITLE
Add fake club repository test module

### DIFF
--- a/app-bot/src/test/kotlin/com/example/bot/test/TestModules.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/test/TestModules.kt
@@ -1,0 +1,22 @@
+package com.example.bot.test
+
+import com.example.bot.data.repo.ClubDto
+import com.example.bot.data.repo.ClubRepository
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+object TestModules {
+    val clubs: Module = module {
+        single<ClubRepository> { FakeClubRepository() }
+    }
+}
+
+private class FakeClubRepository : ClubRepository {
+    override suspend fun listClubs(limit: Int): List<ClubDto> =
+        listOf(
+            ClubDto(id = 1, name = "Club One", shortDescription = null),
+            ClubDto(id = 2, name = "Club Two", shortDescription = null),
+            ClubDto(id = 3, name = "Club Three", shortDescription = null),
+            ClubDto(id = 4, name = "Club Four", shortDescription = null),
+        ).take(limit)
+}


### PR DESCRIPTION
## Summary
- add a Koin test module that supplies a fake ClubRepository returning predefined clubs

## Testing
- ./gradlew :app-bot:test --tests com.example.bot.SmokeRoutesTest --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68e52c1ab27c8321a2266e58316c2893