### PR TITLE
Add DEV profile helper for integration tests

### DIFF
--- a/app-bot/src/test/kotlin/com/example/bot/guestlist/GuestListRoutesTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/guestlist/GuestListRoutesTest.kt
@@ -1,5 +1,6 @@
 package com.example.bot.guestlist
 
+import com.example.bot.testing.applicationDev
 import com.example.bot.testing.createInitData
 import com.example.bot.testing.defaultRequest
 import com.example.bot.testing.header
@@ -189,7 +190,7 @@ class GuestListRoutesTest : StringSpec({
         registerRbacUser(telegramId = 100L, roles = setOf(Role.MANAGER), clubs = setOf(clubId))
 
         testApplication {
-            application { testModule() }
+            applicationDev { testModule() }
             val authedClient = authenticatedClient(telegramId = 100L)
             val response =
                 authedClient.post("/api/guest-lists/${list.id}/import?dry_run=true") {
@@ -223,7 +224,7 @@ class GuestListRoutesTest : StringSpec({
         registerRbacUser(telegramId = 200L, roles = setOf(Role.MANAGER), clubs = setOf(clubId))
 
         testApplication {
-            application { testModule() }
+            applicationDev { testModule() }
             val authedClient = authenticatedClient(telegramId = 200L)
             val response =
                 authedClient.post("/api/guest-lists/${list.id}/import") {
@@ -273,7 +274,7 @@ class GuestListRoutesTest : StringSpec({
         registerRbacUser(telegramId = 300L, roles = setOf(Role.MANAGER), clubs = setOf(clubA))
 
         testApplication {
-            application { testModule() }
+            applicationDev { testModule() }
             val authedClient = authenticatedClient(telegramId = 300L)
             val response = authedClient.get("/api/guest-lists")
             response.status shouldBe HttpStatusCode.OK
@@ -319,7 +320,7 @@ class GuestListRoutesTest : StringSpec({
         repository.addEntry(managerList.id, "Club Guest", "+222", 1, null)
 
         testApplication {
-            application { testModule() }
+            applicationDev { testModule() }
             val authedClient = authenticatedClient(telegramId = 400L)
             val response = authedClient.get("/api/guest-lists")
             response.status shouldBe HttpStatusCode.OK
@@ -349,7 +350,7 @@ class GuestListRoutesTest : StringSpec({
         registerRbacUser(telegramId = 500L, roles = setOf(Role.HEAD_MANAGER), clubs = emptySet())
 
         testApplication {
-            application { testModule() }
+            applicationDev { testModule() }
             val authedClient = authenticatedClient(telegramId = 500L)
             val response = authedClient.get("/api/guest-lists/export")
             response.status shouldBe HttpStatusCode.OK

--- a/app-bot/src/test/kotlin/com/example/bot/routes/CheckinRoutesTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/routes/CheckinRoutesTest.kt
@@ -12,6 +12,7 @@ import com.example.bot.plugins.DataSourceHolder
 import com.example.bot.plugins.configureSecurity
 import com.example.bot.webapp.TEST_BOT_TOKEN
 import com.example.bot.webapp.WebAppInitDataTestHelper
+import com.example.bot.testing.applicationDev
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.header
@@ -156,7 +157,7 @@ class CheckinRoutesTest : StringSpec({
         coEvery { repository.markArrived(entryId, any()) } returns true
 
         testApplication {
-            application { testModule(repository) }
+            applicationDev { testModule(repository) }
             val response =
                 client.post("/api/clubs/$clubId/checkin/scan") {
                     header("X-Telegram-Init-Data", initData)
@@ -177,7 +178,7 @@ class CheckinRoutesTest : StringSpec({
         val initData = validInitData()
 
         testApplication {
-            application { testModule(repository) }
+            applicationDev { testModule(repository) }
             val malformed =
                 client.post("/api/clubs/$clubId/checkin/scan") {
                     header("X-Telegram-Init-Data", initData)
@@ -217,7 +218,7 @@ class CheckinRoutesTest : StringSpec({
         coEvery { repository.getList(listId) } returns null
 
         testApplication {
-            application { testModule(repository) }
+            applicationDev { testModule(repository) }
             val response =
                 client.post("/api/clubs/$clubId/checkin/scan") {
                     header("X-Telegram-Init-Data", initData)
@@ -243,7 +244,7 @@ class CheckinRoutesTest : StringSpec({
         coEvery { repository.findEntry(entryId) } returns null
 
         testApplication {
-            application { testModule(repository) }
+            applicationDev { testModule(repository) }
             val response =
                 client.post("/api/clubs/$clubId/checkin/scan") {
                     header("X-Telegram-Init-Data", initData)
@@ -268,7 +269,7 @@ class CheckinRoutesTest : StringSpec({
         coEvery { repository.findEntry(entryId) } returns entry
 
         testApplication {
-            application { testModule(repository) }
+            applicationDev { testModule(repository) }
             val response =
                 client.post("/api/clubs/$clubId/checkin/scan") {
                     header("X-Telegram-Init-Data", initData)
@@ -294,7 +295,7 @@ class CheckinRoutesTest : StringSpec({
         coEvery { repository.markArrived(entryId, any()) } returns true
 
         testApplication {
-            application { testModule(repository) }
+            applicationDev { testModule(repository) }
             val response =
                 client.post("/api/clubs/$clubId/checkin/scan") {
                     header("X-Telegram-Init-Data", initData)
@@ -320,7 +321,7 @@ class CheckinRoutesTest : StringSpec({
         coEvery { repository.markArrived(entryId, any()) } returns true
 
         testApplication {
-            application { testModule(repository) }
+            applicationDev { testModule(repository) }
             repeat(2) {
                 val response =
                     client.post("/api/clubs/$clubId/checkin/scan") {

--- a/app-bot/src/test/kotlin/com/example/bot/routes/EntryManagerCheckInSmokeTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/routes/EntryManagerCheckInSmokeTest.kt
@@ -20,6 +20,7 @@ import com.example.bot.plugins.installMetrics
 import com.example.bot.plugins.meterRegistry
 import com.example.bot.security.auth.TelegramPrincipal
 import com.example.bot.security.rbac.RbacPlugin
+import com.example.bot.testing.applicationDev
 import com.example.bot.webapp.InitDataPrincipalKey
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -72,7 +73,7 @@ class EntryManagerCheckInSmokeTest {
         testApplication {
             val guestListRepository = TestGuestListRepository()
             val module = baseModule(guestListRepository = guestListRepository)
-            application { configureTestApplication(module) }
+            applicationDev { configureTestApplication(module) }
 
             val issued = fixedNow.minusSeconds(60)
             val qrToken = encodeQr(QR_SECRET, LIST_ID, ENTRY_ID, issued)
@@ -136,7 +137,7 @@ class EntryManagerCheckInSmokeTest {
     fun `malformed or expired qr returns 400`() {
         testApplication {
             val module = baseModule()
-            application { configureTestApplication(module) }
+            applicationDev { configureTestApplication(module) }
 
             val userJson = """{"id":$TELEGRAM_USER_ID,"username":"entry_mgr"}"""
             val initData =
@@ -190,7 +191,7 @@ class EntryManagerCheckInSmokeTest {
             val guestListRepository = TestGuestListRepository()
             guestListRepository.removeList(LIST_ID)
             val module = baseModule(guestListRepository = guestListRepository)
-            application { configureTestApplication(module) }
+            applicationDev { configureTestApplication(module) }
 
             val issued = fixedNow.minusSeconds(30)
             val qrToken = encodeQr(QR_SECRET, LIST_ID, ENTRY_ID, issued)
@@ -221,7 +222,7 @@ class EntryManagerCheckInSmokeTest {
             val guestListRepository = TestGuestListRepository()
             guestListRepository.removeEntry(ENTRY_ID)
             val module = baseModule(guestListRepository = guestListRepository)
-            application { configureTestApplication(module) }
+            applicationDev { configureTestApplication(module) }
 
             val issued = fixedNow.minusSeconds(30)
             val qrToken = encodeQr(QR_SECRET, LIST_ID, ENTRY_ID, issued)
@@ -254,7 +255,7 @@ class EntryManagerCheckInSmokeTest {
                 guestListRepository.currentEntry().copy(listId = LIST_ID + 1),
             )
             val module = baseModule(guestListRepository = guestListRepository)
-            application { configureTestApplication(module) }
+            applicationDev { configureTestApplication(module) }
 
             val issued = fixedNow.minusSeconds(30)
             val qrToken = encodeQr(QR_SECRET, LIST_ID, ENTRY_ID, issued)
@@ -286,7 +287,7 @@ class EntryManagerCheckInSmokeTest {
                 baseModule(
                     userRoleRepository = TestUserRoleRepository(clubIds = setOf(CLUB_ID + 1)),
                 )
-            application { configureTestApplication(module) }
+            applicationDev { configureTestApplication(module) }
 
             val issued = fixedNow.minusSeconds(30)
             val qrToken = encodeQr(QR_SECRET, LIST_ID, ENTRY_ID, issued)
@@ -315,7 +316,7 @@ class EntryManagerCheckInSmokeTest {
     fun `missing or invalid init data returns 401`() {
         testApplication {
             val module = baseModule()
-            application { configureTestApplication(module) }
+            applicationDev { configureTestApplication(module) }
 
             val issued = fixedNow.minusSeconds(30)
             val qrToken = encodeQr(QR_SECRET, LIST_ID, ENTRY_ID, issued)

--- a/app-bot/src/test/kotlin/com/example/bot/routes/MusicRoutesTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/routes/MusicRoutesTest.kt
@@ -12,6 +12,7 @@ import com.example.bot.music.PlaylistView
 import com.example.bot.music.UserId
 import com.example.bot.webapp.TEST_BOT_TOKEN
 import com.example.bot.webapp.WebAppInitDataTestHelper
+import com.example.bot.testing.applicationDev
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
@@ -94,7 +95,7 @@ class MusicRoutesTest {
     @Test
     fun `items endpoint returns list and respects etag`() {
         testApplication {
-            application {
+            applicationDev {
                 install(ContentNegotiation) { json() }
                 musicRoutes(service)
             }
@@ -123,7 +124,7 @@ class MusicRoutesTest {
     @Test
     fun `playlists endpoint returns list`() {
         testApplication {
-            application {
+            applicationDev {
                 install(ContentNegotiation) { json() }
                 musicRoutes(service)
             }
@@ -141,7 +142,7 @@ class MusicRoutesTest {
     @Test
     fun `playlist details return 200 and 404`() {
         testApplication {
-            application {
+            applicationDev {
                 install(ContentNegotiation) { json() }
                 musicRoutes(service)
             }

--- a/app-bot/src/test/kotlin/com/example/bot/routes/SecuredBookingRoutesTest.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/routes/SecuredBookingRoutesTest.kt
@@ -1,5 +1,6 @@
 package com.example.bot.routes
 
+import com.example.bot.testing.applicationDev
 import com.example.bot.testing.createInitData
 import com.example.bot.testing.defaultRequest
 import com.example.bot.testing.header
@@ -141,7 +142,7 @@ class SecuredBookingRoutesTest : StringSpec({
     "returns 401 when principal missing" {
         val bookingService = mockk<BookingService>()
         testApplication {
-            application { testModule(bookingService) }
+            applicationDev { testModule(bookingService) }
             val response =
                 client.post {
                     route("/api/clubs/1/bookings/hold")
@@ -169,7 +170,7 @@ class SecuredBookingRoutesTest : StringSpec({
         val bookingService = mockk<BookingService>()
         registerUser(telegramId = 200L, roles = setOf(Role.MANAGER), clubs = setOf(2L))
         testApplication {
-            application { testModule(bookingService) }
+            applicationDev { testModule(bookingService) }
             val authedClient = authenticatedClient(telegramId = 200L)
             val response =
                 authedClient.post {
@@ -198,7 +199,7 @@ class SecuredBookingRoutesTest : StringSpec({
         val bookingService = mockk<BookingService>()
         registerUser(telegramId = 300L, roles = setOf(Role.MANAGER), clubs = setOf(1L))
         testApplication {
-            application { testModule(bookingService) }
+            applicationDev { testModule(bookingService) }
             val authedClient = authenticatedClient(telegramId = 300L)
             val response =
                 authedClient.post {
@@ -231,7 +232,7 @@ class SecuredBookingRoutesTest : StringSpec({
         coEvery { bookingService.confirm(holdId, "idem-confirm") } returns BookingCmdResult.Booked(bookingId)
 
         testApplication {
-            application { testModule(bookingService) }
+            applicationDev { testModule(bookingService) }
             val authedClient = authenticatedClient(telegramId = 400L)
             val holdResponse =
                 authedClient.post {
@@ -291,7 +292,7 @@ class SecuredBookingRoutesTest : StringSpec({
         coEvery { bookingService.hold(any(), "idem-dup") } returns BookingCmdResult.DuplicateActiveBooking
 
         testApplication {
-            application { testModule(bookingService) }
+            applicationDev { testModule(bookingService) }
             val authedClient = authenticatedClient(telegramId = 500L)
             val response =
                 authedClient.post {
@@ -322,7 +323,7 @@ class SecuredBookingRoutesTest : StringSpec({
         coEvery { bookingService.confirm(holdId, "idem-expire") } returns BookingCmdResult.HoldExpired
 
         testApplication {
-            application { testModule(bookingService) }
+            applicationDev { testModule(bookingService) }
             val authedClient = authenticatedClient(telegramId = 600L)
             val response =
                 authedClient.post {
@@ -342,7 +343,7 @@ class SecuredBookingRoutesTest : StringSpec({
         coEvery { bookingService.confirm(holdId, "idem-missing") } returns BookingCmdResult.NotFound
 
         testApplication {
-            application { testModule(bookingService) }
+            applicationDev { testModule(bookingService) }
             val authedClient = authenticatedClient(telegramId = 700L)
             val response =
                 authedClient.post {

--- a/app-bot/src/test/kotlin/com/example/bot/testing/TestProfiles.kt
+++ b/app-bot/src/test/kotlin/com/example/bot/testing/TestProfiles.kt
@@ -1,0 +1,18 @@
+package com.example.bot.testing
+
+import io.ktor.server.application.Application
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.ApplicationTestBuilder
+
+/**
+ * Запускает Ktor-приложение в профиле DEV (обходит TEST-guard),
+ * не затрагивая глобальные ENV и прочие тесты.
+ */
+fun ApplicationTestBuilder.applicationDev(block: Application.() -> Unit) {
+    environment {
+        config = MapApplicationConfig(
+            "app.profile" to "DEV",
+        )
+    }
+    application(block)
+}


### PR DESCRIPTION
## Summary
- add a reusable applicationDev helper that boots Ktor tests under the DEV profile
- update heavy integration tests to launch the app with the helper so they bypass the TEST guard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5343fdb088321a7737a7c6f6c8c93